### PR TITLE
Add dark mode support with simplified theme toggle

### DIFF
--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from 'react-i18next'
+
+interface ConfirmDialogProps {
+  isOpen: boolean
+  onConfirm: () => void
+  onCancel: () => void
+  title: string
+  message: string
+}
+
+export function ConfirmDialog({ isOpen, onConfirm, onCancel, title, message }: ConfirmDialogProps) {
+  const { t } = useTranslation()
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 dark:bg-black/70"
+      onClick={onCancel}
+    >
+      <div
+        className="bg-white dark:bg-slate-800 rounded-lg shadow-xl p-6 max-w-md w-full mx-4"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-labelledby="dialog-title"
+        aria-describedby="dialog-message"
+      >
+        <h2 id="dialog-title" className="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-4">
+          {title}
+        </h2>
+        <p id="dialog-message" className="text-slate-600 dark:text-slate-300 mb-6">
+          {message}
+        </p>
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 rounded-lg border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors"
+          >
+            {t('dialog.cancel')}
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-4 py-2 rounded-lg bg-red-600 dark:bg-red-700 text-white hover:bg-red-700 dark:hover:bg-red-800 transition-colors"
+          >
+            {t('dialog.confirm')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -39,13 +39,13 @@ const Toast: React.FC<ToastProps> = ({ toast, onRemove }) => {
   const getStyles = () => {
     switch (toast.type) {
       case 'success':
-        return 'bg-green-50 border-green-200 text-green-800';
+        return 'bg-teal-50 dark:bg-teal-900 border-teal-200 dark:border-teal-700 text-teal-800 dark:text-teal-100';
       case 'error':
-        return 'bg-red-50 border-red-200 text-red-800';
+        return 'bg-red-50 dark:bg-red-900 border-red-200 dark:border-red-700 text-red-800 dark:text-red-100';
       case 'warning':
-        return 'bg-yellow-50 border-yellow-200 text-yellow-800';
+        return 'bg-yellow-50 dark:bg-yellow-900 border-yellow-200 dark:border-yellow-700 text-yellow-800 dark:text-yellow-100';
       case 'info':
-        return 'bg-blue-50 border-blue-200 text-blue-800';
+        return 'bg-slate-50 dark:bg-slate-800 border-slate-200 dark:border-slate-600 text-slate-800 dark:text-slate-100';
     }
   };
 

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,44 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useEffect, useState } from 'react'
+import type { ReactNode } from 'react'
+
+type Theme = 'light' | 'dark'
+
+interface ThemeContextType {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+  toggleTheme: () => void
+}
+
+export const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
+
+interface ThemeProviderProps {
+  children: ReactNode
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const stored = localStorage.getItem('theme') as Theme
+    if (stored === 'light' || stored === 'dark') {
+      return stored
+    }
+    // Auto-detect system preference on first load only
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  })
+
+  useEffect(() => {
+    const root = document.documentElement
+    root.classList.toggle('dark', theme === 'dark')
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'))
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react'
+import { ThemeContext } from '../contexts/ThemeContext'
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+  return context
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -49,6 +49,7 @@
     "enterCalculationName": "Please enter a calculation name",
     "performCalculationFirst": "Please perform calculation first",
     "saved": "Calculation result saved",
+    "deleted": "Calculation deleted successfully",
     "copiedToClipboard": "JSON data copied to clipboard",
     "copyFailed": "Copy failed. Please copy manually.",
     "jsonLoaded": "Calculation data loaded from JSON file",
@@ -57,5 +58,18 @@
     "jsonDownloaded": "JSON file downloaded successfully",
     "presetLoadError": "Failed to load some preset files. Check console for details.",
     "presetValidationError": "Preset data validation error: {{details}}"
+  },
+  "theme": {
+    "light": "Light Mode",
+    "dark": "Dark Mode",
+    "toggle": "Toggle Theme"
+  },
+  "dialog": {
+    "deleteConfirm": {
+      "title": "Confirm Deletion",
+      "message": "Are you sure you want to delete this saved calculation?"
+    },
+    "cancel": "Cancel",
+    "confirm": "Delete"
   }
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -49,6 +49,7 @@
     "enterCalculationName": "計算名を入力してください",
     "performCalculationFirst": "まず計算を実行してください",
     "saved": "計算結果を保存しました",
+    "deleted": "計算を削除しました",
     "copiedToClipboard": "JSONデータをクリップボードにコピーしました",
     "copyFailed": "コピーに失敗しました。手動でコピーしてください。",
     "jsonLoaded": "JSONファイルから計算データを読み込みました",
@@ -57,5 +58,18 @@
     "jsonDownloaded": "JSONファイルのダウンロードが完了しました",
     "presetLoadError": "一部のプリセットファイルの読み込みに失敗しました。詳細はコンソールを確認してください。",
     "presetValidationError": "プリセットデータの検証エラー: {{details}}"
+  },
+  "theme": {
+    "light": "ライトモード",
+    "dark": "ダークモード",
+    "toggle": "テーマ切替"
+  },
+  "dialog": {
+    "deleteConfirm": {
+      "title": "削除の確認",
+      "message": "この保存された計算を削除してもよろしいですか？"
+    },
+    "cancel": "キャンセル",
+    "confirm": "削除"
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,11 +4,14 @@ import './index.css'
 import './i18n'
 import App from './App.tsx'
 import { ToastProvider } from './contexts/ToastContext'
+import { ThemeProvider } from './contexts/ThemeContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ToastProvider>
-      <App />
-    </ToastProvider>
+    <ThemeProvider>
+      <ToastProvider>
+        <App />
+      </ToastProvider>
+    </ThemeProvider>
   </StrictMode>,
 )

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,7 @@ export default {
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
+  darkMode: 'class',
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- Implemented dark mode functionality with Tailwind CSS
- Added ThemeContext for global theme state management
- Created theme toggle button with sun/moon icons
- Simplified theme switching to 2-state toggle (light ↔ dark)
- Auto-detects system preference on first load only
- Added localization support for theme-related UI elements
- Integrated theme support across Toast and ConfirmDialog components

## Key Changes
- New `ThemeContext` provides theme state management
- New `useTheme` hook for consuming theme context
- Updated `App.tsx` with theme toggle button
- Updated `tailwind.config.js` to enable dark mode
- Added theme-aware styling to components
- Theme preference persists in localStorage

## Test plan
- [x] Verify theme toggle switches between light and dark modes
- [x] Confirm theme preference persists after page reload
- [x] Test initial theme auto-detection based on system preference
- [x] Verify all UI components display correctly in both themes
- [x] Check localization strings appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)