### PR TITLE
日本語モードに Noto Sans JP フォント適用 & lang 属性動的切替

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/png" href="/calculator.svg" />
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spoke Length Calculator</title>
   <script>
@@ -15,6 +15,7 @@
       if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
         document.documentElement.classList.add('dark');
       }
+      document.documentElement.lang = localStorage.getItem('preferredLanguage') || 'en';
     })();
   </script>
 </head>

--- a/index.html
+++ b/index.html
@@ -1,9 +1,12 @@
 <!doctype html>
-<html lang="en">
+<html>
 
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/png" href="/calculator.svg" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spoke Length Calculator</title>
   <script>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -275,7 +275,15 @@ const SpokeLengthCalculator: React.FC = () => {
   const handleLanguageChange = (lang: string) => {
     i18n.changeLanguage(lang);
     localStorage.setItem('preferredLanguage', lang);
+    document.documentElement.lang = lang;
+    document.documentElement.classList.toggle('lang-ja', lang === 'ja');
   };
+
+  // Set lang attribute and font class on initial load
+  useEffect(() => {
+    document.documentElement.lang = i18n.language;
+    document.documentElement.classList.toggle('lang-ja', i18n.language === 'ja');
+  }, []);
 
   // Load saved calculations from local storage
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -276,14 +276,12 @@ const SpokeLengthCalculator: React.FC = () => {
     i18n.changeLanguage(lang);
     localStorage.setItem('preferredLanguage', lang);
     document.documentElement.lang = lang;
-    document.documentElement.classList.toggle('lang-ja', lang === 'ja');
   };
 
-  // Set lang attribute and font class on initial load
+  // Keep lang attribute in sync with i18n language
   useEffect(() => {
     document.documentElement.lang = i18n.language;
-    document.documentElement.classList.toggle('lang-ja', i18n.language === 'ja');
-  }, []);
+  }, [i18n.language]);
 
   // Load saved calculations from local storage
   useEffect(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.lang-ja {
+  font-family: 'Noto Sans JP', sans-serif;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-.lang-ja {
+html:lang(ja) {
   font-family: 'Noto Sans JP', sans-serif;
 }


### PR DESCRIPTION
## Summary
- 日本語モード時に Google Fonts の **Noto Sans JP** を適用し、日本語テキストの表示品質を向上
- `<html>` の `lang` 属性を言語切替に連動して動的に設定（`en` / `ja`）
- 初期ロード時にも保存済み言語に基づいてフォント・lang 属性を正しく適用

Closes #10

## Test plan
- [x] 英語モードでシステムフォントが使われていることを DevTools で確認
- [x] 日本語モードに切替後、Noto Sans JP が適用されることを確認
- [x] `<html>` の `lang` 属性が `en` / `ja` に動的に切り替わることを確認
- [x] ページリロード後も保存済み言語に応じてフォント・lang が正しく適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)