### PR TITLE
Add wheel comparison and spoke purchase suggestion (#31)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { useTheme } from './hooks/useTheme';
 import { ConfirmDialog } from './components/ConfirmDialog';
 import { HelpButton } from './components/HelpButton';
 import { HelpModal, type HelpTopic } from './components/HelpModal';
+import CompareWheels, { type WheelOption } from './components/CompareWheels';
 
 // Dynamic import of preset data
 const presetModules = import.meta.glob('./presets/*.json', { eager: true });
@@ -560,6 +561,9 @@ const SpokeLengthCalculator: React.FC = () => {
   const [helpTopic, setHelpTopic] = useState<HelpTopic | null>(null);
   const [touchedFields, setTouchedFields] = useState<TouchedFields>({});
   const savedCalculationsLoadedRef = useRef(false);
+  const [showCompare, setShowCompare] = useState(false);
+  const [compareA, setCompareA] = useState('');
+  const [compareB, setCompareB] = useState('');
 
   const calculation = useMemo(() => getCalculationState(inputs), [inputs]);
   const currentResults = calculation.results;
@@ -577,6 +581,33 @@ const SpokeLengthCalculator: React.FC = () => {
     return errors;
   }, [calculation.fieldErrors, inputs, t, touchedFields]);
   const hasValidResults = currentResults !== null;
+
+  const wheelOptions = useMemo((): WheelOption[] => {
+    const presetItems: WheelOption[] = presetOptions.map(p => ({
+      id: `preset:${p.id}`,
+      label: p.name,
+      group: 'preset',
+      spec: {
+        label: p.name,
+        leftLength: p.data.results.left,
+        rightLength: p.data.results.right,
+        spokeCount: parseInt(p.data.inputs.numberOfSpokes, 10) || 32,
+      },
+    }));
+    const savedItems: WheelOption[] = savedCalculations.map(s => ({
+      id: `saved:${s.id}`,
+      label: s.name,
+      group: 'saved',
+      spec: {
+        label: s.name,
+        leftLength: s.results.left,
+        rightLength: s.results.right,
+        spokeCount: parseInt(s.inputs.numberOfSpokes, 10) || 32,
+      },
+    }));
+    return [...presetItems, ...savedItems];
+  }, [presetOptions, savedCalculations]);
+
   const titleText = t(isCompactViewport ? 'titleShort' : 'title');
   const resultsLeftText = t(isCompactViewport ? 'results.leftShort' : 'results.left');
   const resultsRightText = t(isCompactViewport ? 'results.rightShort' : 'results.right');
@@ -1288,6 +1319,29 @@ const SpokeLengthCalculator: React.FC = () => {
             </div>
           )}
         </div>
+      </div>
+
+      {/* Wheel compare section */}
+      <div className="mt-10">
+        <button
+          onClick={() => setShowCompare(prev => !prev)}
+          className="w-full flex items-center justify-between px-4 py-3 rounded-lg border border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-800/50 hover:bg-slate-100 dark:hover:bg-slate-700/50 text-slate-700 dark:text-slate-300 font-medium transition-colors"
+        >
+          <span>{t('compare.toggle')}</span>
+          <span className="text-slate-400 dark:text-slate-500">{showCompare ? '▲' : '▼'}</span>
+        </button>
+        {showCompare && (
+          <div className="mt-4 rounded-lg border border-slate-200 dark:border-slate-600 p-5">
+            <h2 className="text-lg font-semibold text-slate-700 dark:text-slate-300 mb-4">{t('compare.heading')}</h2>
+            <CompareWheels
+              options={wheelOptions}
+              selectedA={compareA}
+              selectedB={compareB}
+              onChangeA={setCompareA}
+              onChangeB={setCompareB}
+            />
+          </div>
+        )}
       </div>
 
       {/* JSON data display modal */}

--- a/src/components/CompareWheels.tsx
+++ b/src/components/CompareWheels.tsx
@@ -1,0 +1,133 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { compareWheels, type WheelSpec } from '../spokeCompare';
+
+export interface WheelOption {
+  id: string;
+  label: string;
+  group: 'preset' | 'saved';
+  spec: WheelSpec;
+}
+
+interface Props {
+  options: WheelOption[];
+  selectedA: string;
+  selectedB: string;
+  onChangeA: (id: string) => void;
+  onChangeB: (id: string) => void;
+}
+
+const selectClass =
+  'w-full px-3 py-2 border rounded-md bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 border-slate-300 dark:border-slate-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors';
+
+const CompareWheels: React.FC<Props> = ({ options, selectedA, selectedB, onChangeA, onChangeB }) => {
+  const { t } = useTranslation();
+
+  const presets = options.filter(o => o.group === 'preset');
+  const saved = options.filter(o => o.group === 'saved');
+
+  const specA = options.find(o => o.id === selectedA)?.spec ?? null;
+  const specB = options.find(o => o.id === selectedB)?.spec ?? null;
+
+  const result = useMemo(() => {
+    if (specA === null || specB === null) return null;
+    return compareWheels(specA, specB);
+  }, [specA, specB]);
+
+  const renderSelect = (
+    value: string,
+    onChange: (id: string) => void,
+    label: string,
+  ) => (
+    <div className="flex flex-col gap-1">
+      <label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+        {label}
+      </label>
+      <select
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        className={selectClass}
+      >
+        <option value="">{t('compare.placeholder')}</option>
+        {presets.length > 0 && (
+          <optgroup label={t('compare.groupPresets')}>
+            {presets.map(o => (
+              <option key={o.id} value={o.id}>{o.label}</option>
+            ))}
+          </optgroup>
+        )}
+        {saved.length > 0 && (
+          <optgroup label={t('compare.groupSaved')}>
+            {saved.map(o => (
+              <option key={o.id} value={o.id}>{o.label}</option>
+            ))}
+          </optgroup>
+        )}
+      </select>
+    </div>
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {renderSelect(selectedA, onChangeA, t('compare.wheelA'))}
+        {renderSelect(selectedB, onChangeB, t('compare.wheelB'))}
+      </div>
+
+      {result === null ? (
+        <p className="text-sm text-slate-500 dark:text-slate-400 text-center py-4">
+          {t('compare.selectBoth')}
+        </p>
+      ) : (
+        <div className="rounded-lg border bg-blue-50 dark:bg-blue-950/30 border-blue-200 dark:border-blue-800 p-5 space-y-4">
+          <div className="grid grid-cols-3 gap-3 text-center">
+            <div>
+              <p className="text-xs text-slate-500 dark:text-slate-400">{t('compare.totalNeeded')}</p>
+              <p className="text-xl font-bold text-blue-800 dark:text-blue-400">{result.totalNeeded}</p>
+            </div>
+            <div>
+              <p className="text-xs text-slate-500 dark:text-slate-400">{t('compare.reuseCount')}</p>
+              <p className="text-xl font-bold text-blue-800 dark:text-blue-400">{result.reuseCount}</p>
+            </div>
+            <div>
+              <p className="text-xs text-slate-500 dark:text-slate-400">{t('compare.leftoverCount')}</p>
+              <p className="text-xl font-bold text-slate-600 dark:text-slate-300">{result.leftoverCount}</p>
+            </div>
+          </div>
+
+          <div>
+            <p className="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-2">
+              {t('compare.buyHeading')}
+            </p>
+            {result.buyItems.length === 0 ? (
+              <p className="text-sm text-green-700 dark:text-green-400">{t('compare.noBuy')}</p>
+            ) : (
+              <ul className="space-y-1">
+                {result.buyItems.map((item, i) => (
+                  <li key={i} className="text-sm text-slate-800 dark:text-slate-200">
+                    {t('compare.buyItem', { length: item.length.toFixed(1), count: item.count })}
+                    <span className="text-xs text-slate-500 dark:text-slate-400 ml-1">
+                      ({item.side === 'left' ? t('compare.sideLeft') : t('compare.sideRight')})
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {result.reuseCount === 0 && result.buyItems.length > 0 && (
+            <p className="text-sm text-amber-700 dark:text-amber-400">{t('compare.allNew')}</p>
+          )}
+
+          {result.combinable && result.buyItems.length > 0 && (
+            <p className="text-sm text-blue-700 dark:text-blue-400">{t('compare.combinable')}</p>
+          )}
+
+          <p className="text-xs text-slate-400 dark:text-slate-500">{t('compare.note')}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CompareWheels;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -131,5 +131,26 @@
     },
     "cancel": "Cancel",
     "confirm": "Delete"
+  },
+  "compare": {
+    "heading": "Compare Wheels & Spoke Suggestion",
+    "toggle": "Compare Wheels",
+    "wheelA": "Current Wheel (spokes you have)",
+    "wheelB": "New Wheel (spokes you need)",
+    "placeholder": "Select a wheel",
+    "groupPresets": "Presets",
+    "groupSaved": "Saved Calculations",
+    "totalNeeded": "Spokes needed (B)",
+    "reuseCount": "Reusable from current wheel",
+    "leftoverCount": "Leftover spokes from current wheel",
+    "buyHeading": "Spokes to buy",
+    "buyItem": "{{length}} mm × {{count}} pcs",
+    "sideLeft": "Left",
+    "sideRight": "Right",
+    "noBuy": "No additional spokes needed — all can be reused.",
+    "combinable": "Both sides require the same length (within ±1 mm) — you can order one length for both sides.",
+    "allNew": "No spokes can be reused — full replacement required.",
+    "note": "* Reuse is based on length only (±1 mm tolerance). Spoke gauge and fatigue are not considered.",
+    "selectBoth": "Select both wheels to see the suggestion."
   }
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -131,5 +131,26 @@
     },
     "cancel": "キャンセル",
     "confirm": "削除"
+  },
+  "compare": {
+    "heading": "ホイール比較・スポーク買い足し提案",
+    "toggle": "ホイールを比較",
+    "wheelA": "現状ホイール（手持ちスポーク）",
+    "wheelB": "交換後ホイール（必要なスポーク）",
+    "placeholder": "ホイールを選択",
+    "groupPresets": "プリセット",
+    "groupSaved": "保存済み計算",
+    "totalNeeded": "必要本数（B）",
+    "reuseCount": "現状ホイールから流用できる本数",
+    "leftoverCount": "流用後に余る本数",
+    "buyHeading": "買い足しスポーク",
+    "buyItem": "{{length}} mm × {{count}} 本",
+    "sideLeft": "左",
+    "sideRight": "右",
+    "noBuy": "買い足し不要 — すべて流用できます。",
+    "combinable": "左右の必要長が±1mm以内です — 1種類の長さでまとめて注文できます。",
+    "allNew": "流用できるスポークがありません — 全数交換が必要です。",
+    "note": "※ 流用判定は長さのみで行います（許容差±1mm）。スポークのゲージや疲労は考慮しません。",
+    "selectBoth": "両方のホイールを選択すると提案が表示されます。"
   }
 }

--- a/src/spokeCompare.ts
+++ b/src/spokeCompare.ts
@@ -1,0 +1,97 @@
+export const SPOKE_TOLERANCE_MM = 1;
+
+export interface WheelSpec {
+  label: string;
+  leftLength: number;
+  rightLength: number;
+  spokeCount: number;
+}
+
+export interface BuyItem {
+  length: number;
+  count: number;
+  side: 'left' | 'right';
+}
+
+export interface CompareResult {
+  totalNeeded: number;
+  reuseCount: number;
+  leftoverCount: number;
+  buyItems: BuyItem[];
+  combinable: boolean;
+}
+
+export function compareWheels(
+  current: WheelSpec,
+  target: WheelSpec,
+  toleranceMm = SPOKE_TOLERANCE_MM,
+): CompareResult {
+  const perSideCurrent = current.spokeCount / 2;
+  const perSideTarget = target.spokeCount / 2;
+
+  // Supply pool: [leftLength x perSideCurrent, rightLength x perSideCurrent]
+  const supply = [
+    { length: current.leftLength, count: perSideCurrent },
+    { length: current.rightLength, count: perSideCurrent },
+  ];
+
+  // Demand groups: left and right of target wheel
+  const demands: { length: number; count: number; side: 'left' | 'right' }[] = [
+    { length: target.leftLength, count: perSideTarget, side: 'left' },
+    { length: target.rightLength, count: perSideTarget, side: 'right' },
+  ];
+
+  const canReuse = (supplyLength: number, demandLength: number): boolean =>
+    Math.abs(supplyLength - demandLength) <= toleranceMm;
+
+  // Try all orderings of demand groups; pick the one that maximises reuse
+  let bestReuse = -1;
+  let bestSupplyAfter: { length: number; count: number }[] = [];
+  let bestDemandShortfall: { length: number; count: number; side: 'left' | 'right' }[] = [];
+
+  const orders = [
+    [0, 1],
+    [1, 0],
+  ];
+
+  for (const order of orders) {
+    const localSupply = supply.map(s => ({ ...s }));
+    const shortfalls: { length: number; count: number; side: 'left' | 'right' }[] = [];
+    let totalReuse = 0;
+
+    for (const di of order) {
+      const demand = demands[di];
+      let remaining = demand.count;
+
+      for (const s of localSupply) {
+        if (remaining <= 0) break;
+        if (!canReuse(s.length, demand.length)) continue;
+        const used = Math.min(s.count, remaining);
+        s.count -= used;
+        remaining -= used;
+        totalReuse += used;
+      }
+
+      if (remaining > 0) {
+        shortfalls.push({ length: demand.length, count: remaining, side: demand.side });
+      }
+    }
+
+    if (totalReuse > bestReuse) {
+      bestReuse = totalReuse;
+      bestSupplyAfter = localSupply;
+      bestDemandShortfall = shortfalls;
+    }
+  }
+
+  const totalNeeded = target.spokeCount;
+  const reuseCount = bestReuse;
+  const leftoverCount = bestSupplyAfter.reduce((sum, s) => sum + s.count, 0);
+  const buyItems: BuyItem[] = bestDemandShortfall
+    .filter(s => s.count > 0)
+    .map(s => ({ length: s.length, count: s.count, side: s.side }));
+
+  const combinable = Math.abs(target.leftLength - target.rightLength) <= toleranceMm;
+
+  return { totalNeeded, reuseCount, leftoverCount, buyItems, combinable };
+}


### PR DESCRIPTION
## Summary

- Closes #31
- 保存済み計算またはプリセットから2件のホイール構成を選択し、±1mm許容差で手持ちスポークの流用可否を判定して買い足し本数（長さ別）を提案するパネルを追加
- スポークは長さが合えば左右入れ替えて使えるため、左右スワップを含む全探索で流用本数を最大化するアルゴリズムを実装
- 「ホイールを比較」ボタンで折りたたみ表示、日英両言語対応

## Changes

- `src/spokeCompare.ts` — 純粋ロジック（`compareWheels()`、最大流用マッチング）
- `src/components/CompareWheels.tsx` — 比較UIパネル（プリセット/保存済みを `<optgroup>` で分類）
- `src/App.tsx` — トグル state、`wheelOptions` useMemo、パネル描画を追加（最小変更）
- `src/locales/{en,ja}.json` — `compare.*` 翻訳キー追加

## Test plan

- [x] A=B同一構成 → 買い足し0本・「全流用可」
- [x] IS6 Front→IS6 Rear（左右入れ替え） → 流用32本・買い足し0本（数学的に正しい）
- [x] IS6 Front→CL Front → 流用16本・買い足し283.9mm×16本(Right)・combinable注記
- [x] 片方のみ選択 → 「両方選択してください」プレースホルダー表示
- [x] 日英切り替えで全文言が両言語で正しく表示
- [x] `npm run build`（tsc 型チェック含む）と `npm run lint` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)