### PR TITLE
リムオフセット入力を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Most of the code in this project was created with [Claude Code](https://claude.a
   - Hope Pro 5 IS6 + Nextie Premium 2936 (Front/Rear)
 - **Rich input parameters**:
   - ERD (Effective Rim Diameter)
+  - Rim offset (automatically applied to reduce the effective left/right flange-distance difference)
   - Left and right hub flange PCD (Pitch Circle Diameter)
   - Distance between left and right flanges
   - Spoke hole diameter

--- a/README_ja.md
+++ b/README_ja.md
@@ -21,6 +21,7 @@ GitHub pages: https://llongmane584.github.io/spoke-length-calculator/
   - Hope Pro 5 IS6 + Nextie Premium 2936（フロント/リア）
 - **豊富な入力パラメータ**:
   - ERD（有効リム径）
+  - リムオフセット（左右の実効フランジ距離差を縮める方向へ自動適用）
   - 左右ハブフランジのPCD（ピッチ円直径）
   - 左右フランジ間距離
   - スポーク穴径

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ const presetModules = import.meta.glob('./presets/*.json', { eager: true });
 // Type definitions
 interface Inputs {
   erd: string;
+  rimOffset: string;
   pitchCircleLeft: string;
   pitchCircleRight: string;
   flangeDistanceLeft: string;
@@ -63,6 +64,7 @@ type TouchedFields = Partial<Record<InputField, boolean>>;
 
 interface ParsedInputs {
   erd: number;
+  rimOffset: number;
   pitchCircleLeft: number;
   pitchCircleRight: number;
   flangeDistanceLeft: number;
@@ -80,6 +82,7 @@ interface CalculationState {
 
 const inputFields = [
   'erd',
+  'rimOffset',
   'pitchCircleLeft',
   'pitchCircleRight',
   'flangeDistanceLeft',
@@ -97,6 +100,7 @@ const getIsCompactViewport = () =>
 
 const numericFieldRules: Record<NumericInputField, { min: number; max: number; rangeError: string }> = {
   erd: { min: 1, max: 1000, rangeError: 'validation.rangeErd' },
+  rimOffset: { min: 0, max: 100, rangeError: 'validation.rangeRimOffset' },
   pitchCircleLeft: { min: 1, max: 100, rangeError: 'validation.rangeStandard' },
   pitchCircleRight: { min: 1, max: 100, rangeError: 'validation.rangeStandard' },
   flangeDistanceLeft: { min: 1, max: 100, rangeError: 'validation.rangeStandard' },
@@ -139,7 +143,9 @@ const normalizeInputs = (value: unknown): Inputs | null => {
   const normalized: Partial<Inputs> = {};
 
   for (const field of inputFields) {
-    const normalizedValue = normalizeInputValue(value[field]);
+    const normalizedValue = field === 'rimOffset' && value[field] === undefined
+      ? '0'
+      : normalizeInputValue(value[field]);
 
     if (normalizedValue === null) {
       return null;
@@ -269,11 +275,48 @@ const validateInputs = (inputs: Inputs): { parsed: ParsedInputs | null; fieldErr
     };
   }
 
+  const effectiveFlangeDistances = getEffectiveFlangeDistances(completeParsed);
+
+  if (effectiveFlangeDistances.left <= 0 || effectiveFlangeDistances.right <= 0) {
+    return {
+      parsed: null,
+      fieldErrors: {
+        rimOffset: 'validation.rimOffsetTooLarge',
+      },
+    };
+  }
+
   return { parsed: completeParsed, fieldErrors };
+};
+
+const getEffectiveFlangeDistances = (
+  inputs: Pick<ParsedInputs, 'flangeDistanceLeft' | 'flangeDistanceRight' | 'rimOffset'>,
+): { left: number; right: number } => {
+  const { flangeDistanceLeft, flangeDistanceRight, rimOffset } = inputs;
+
+  if (flangeDistanceLeft > flangeDistanceRight) {
+    return {
+      left: flangeDistanceLeft - rimOffset,
+      right: flangeDistanceRight + rimOffset,
+    };
+  }
+
+  if (flangeDistanceRight > flangeDistanceLeft) {
+    return {
+      left: flangeDistanceLeft + rimOffset,
+      right: flangeDistanceRight - rimOffset,
+    };
+  }
+
+  return {
+    left: flangeDistanceLeft,
+    right: flangeDistanceRight,
+  };
 };
 
 const calculateSpokeResults = (inputs: ParsedInputs): Results | null => {
   const spokesPerSide = inputs.numberOfSpokes / 2;
+  const effectiveFlangeDistances = getEffectiveFlangeDistances(inputs);
 
   if (!Number.isFinite(spokesPerSide) || spokesPerSide <= 0) {
     return null;
@@ -310,8 +353,8 @@ const calculateSpokeResults = (inputs: ParsedInputs): Results | null => {
     return roundedLength;
   };
 
-  const left = calculateLength(inputs.pitchCircleLeft, inputs.flangeDistanceLeft, inputs.crossingsLeft);
-  const right = calculateLength(inputs.pitchCircleRight, inputs.flangeDistanceRight, inputs.crossingsRight);
+  const left = calculateLength(inputs.pitchCircleLeft, effectiveFlangeDistances.left, inputs.crossingsLeft);
+  const right = calculateLength(inputs.pitchCircleRight, effectiveFlangeDistances.right, inputs.crossingsRight);
 
   if (left === null || right === null) {
     return null;
@@ -540,6 +583,7 @@ const SpokeLengthCalculator: React.FC = () => {
   const [isCompactViewport, setIsCompactViewport] = useState(getIsCompactViewport);
   const [inputs, setInputs] = useState<Inputs>({
     erd: '',
+    rimOffset: '0',
     pitchCircleLeft: '',
     pitchCircleRight: '',
     flangeDistanceLeft: '',
@@ -1016,23 +1060,43 @@ const SpokeLengthCalculator: React.FC = () => {
               </div>
             )}
 
-            <div>
-              <div className="flex items-center gap-1 mb-1">
-                <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">{t('input.erd')}</label>
-                <HelpButton topic="erd" onOpen={setHelpTopic} />
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <div className="flex items-center gap-1 mb-1">
+                  <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">{t('input.erd')}</label>
+                  <HelpButton topic="erd" onOpen={setHelpTopic} />
+                </div>
+                <NumberInput
+                  id="erd"
+                  value={inputs.erd}
+                  onChange={(value) => handleInputChange('erd', value)}
+                  onBlur={() => markFieldTouched('erd')}
+                  step={1}
+                  min={1}
+                  max={1000}
+                  error={visibleFieldErrors.erd}
+                  placeholder={t('input.erdPlaceholder')}
+                />
+                <FieldError id="erd-error" message={visibleFieldErrors.erd} />
               </div>
-              <NumberInput
-                id="erd"
-                value={inputs.erd}
-                onChange={(value) => handleInputChange('erd', value)}
-                onBlur={() => markFieldTouched('erd')}
-                step={1}
-                min={1}
-                max={1000}
-                error={visibleFieldErrors.erd}
-                placeholder={t('input.erdPlaceholder')}
-              />
-              <FieldError id="erd-error" message={visibleFieldErrors.erd} />
+              <div>
+                <div className="flex items-center gap-1 mb-1">
+                  <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">{t('input.rimOffset')}</label>
+                  <HelpButton topic="rimOffset" onOpen={setHelpTopic} />
+                </div>
+                <NumberInput
+                  id="rimOffset"
+                  value={inputs.rimOffset}
+                  onChange={(value) => handleInputChange('rimOffset', value)}
+                  onBlur={() => markFieldTouched('rimOffset')}
+                  step={0.1}
+                  min={0}
+                  max={100}
+                  error={visibleFieldErrors.rimOffset}
+                  placeholder={t('input.rimOffsetPlaceholder')}
+                />
+                <FieldError id="rimOffset-error" message={visibleFieldErrors.rimOffset} />
+              </div>
             </div>
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -4,6 +4,7 @@ import { X } from 'lucide-react'
 
 export type HelpTopic =
   | 'erd'
+  | 'rimOffset'
   | 'pcd'
   | 'flangeDistance'
   | 'spokeHoleDiameter'
@@ -41,6 +42,29 @@ function ErdDiagram() {
       <text x="160" y="94" textAnchor="middle" fontSize="13" fill={ACCENT} fontWeight="600">ERD</text>
       <circle cx="160" cy="42" r="3" fill={ACCENT} />
       <text x="160" y="32" textAnchor="middle" fontSize="10" fill="currentColor">{t('input.help.erd.diagram.nippleSeat')}</text>
+    </svg>
+  )
+}
+
+function RimOffsetDiagram() {
+  return (
+    <svg viewBox="0 0 320 200" className="w-full max-w-sm h-auto text-slate-700 dark:text-slate-200" aria-hidden="true">
+      <ArrowDefs />
+      {/* hub and axle */}
+      <line x1="45" y1="145" x2="275" y2="145" stroke="currentColor" strokeWidth="3" />
+      <rect x="105" y="132" width="110" height="26" fill="none" stroke="currentColor" strokeWidth="1.5" />
+      <line x1="105" y1="105" x2="105" y2="170" stroke="currentColor" strokeWidth="3" />
+      <line x1="215" y1="105" x2="215" y2="170" stroke="currentColor" strokeWidth="3" />
+      {/* rim center plane and offset nipple bed */}
+      <path d="M 122 38 Q 160 22 198 38 L 188 72 Q 160 60 132 72 Z" fill="none" stroke="currentColor" strokeWidth="2" />
+      <line x1="160" y1="18" x2="160" y2="176" stroke="currentColor" strokeDasharray="4 3" strokeWidth="1" opacity="0.55" />
+      <line x1="178" y1="34" x2="178" y2="82" stroke={ACCENT} strokeWidth="3" />
+      <circle cx="178" cy="64" r="4" fill={ACCENT} />
+      {/* spokes and offset measurement */}
+      <line x1="105" y1="112" x2="178" y2="64" stroke="currentColor" strokeWidth="1.5" />
+      <line x1="215" y1="112" x2="178" y2="64" stroke="currentColor" strokeWidth="1.5" />
+      <line x1="160" y1="92" x2="178" y2="92" stroke={ACCENT} strokeWidth="1.5" markerStart="url(#hm-arr-start)" markerEnd="url(#hm-arr-end)" />
+      <text x="169" y="108" textAnchor="middle" fontSize="11" fill={ACCENT} fontWeight="600">offset</text>
     </svg>
   )
 }
@@ -178,6 +202,7 @@ function CrossingsDiagram() {
 
 const DIAGRAMS: Record<HelpTopic, () => React.ReactElement> = {
   erd: ErdDiagram,
+  rimOffset: RimOffsetDiagram,
   pcd: PcdDiagram,
   flangeDistance: FlangeDistanceDiagram,
   spokeHoleDiameter: SpokeHoleDiameterDiagram,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -8,6 +8,8 @@
     "presetOption": "Please Select",
     "erd": "ERD (mm)",
     "erdPlaceholder": "Effective Rim Diameter",
+    "rimOffset": "Rim Offset (mm)",
+    "rimOffsetPlaceholder": "Offset amount",
     "pcdLeft": "PCD [L] (mm)",
     "pcdRight": "PCD [R] (mm)",
     "pcdLeftPlaceholder": "Left Side",
@@ -31,6 +33,11 @@
         "diagram": {
           "nippleSeat": "nipple seat"
         }
+      },
+      "rimOffset": {
+        "title": "Rim Offset",
+        "description": "The lateral displacement from the rim center plane to the spoke holes (nipple seats).\n\nEnter an unsigned offset amount. The calculator automatically applies it in the direction that reduces the difference between the effective left and right center-to-flange distances. If both flange distances are equal, the offset does not affect the calculation.\n\nUnit: mm.",
+        "ariaLabel": "Help for Rim Offset"
       },
       "pcd": {
         "title": "PCD (Pitch Circle Diameter)",
@@ -70,8 +77,10 @@
     "selectRequired": "Select one",
     "invalidNumber": "Enter a number",
     "rangeErd": "1-1000mm",
+    "rangeRimOffset": "0-100mm",
     "rangeStandard": "1-100mm",
     "rangeSpokeHole": "1.0-3.0mm",
+    "rimOffsetTooLarge": "Makes an effective flange distance 0mm or less",
     "selectSpokeCount": "24/28/32/36",
     "selectCrossings": "Select 0-4",
     "calculationUnavailable": "Cannot calculate"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -8,6 +8,8 @@
     "presetOption": "選択してください",
     "erd": "ERD (mm)",
     "erdPlaceholder": "有効リム直径",
+    "rimOffset": "リムオフセット (mm)",
+    "rimOffsetPlaceholder": "オフセット量",
     "pcdLeft": "PCD [左] (mm)",
     "pcdRight": "PCD [右] (mm)",
     "pcdLeftPlaceholder": "左側",
@@ -31,6 +33,11 @@
         "diagram": {
           "nippleSeat": "ニップル座面"
         }
+      },
+      "rimOffset": {
+        "title": "リムオフセット",
+        "description": "リム中心面からスポーク穴（ニップル座面）までの左右方向のずれです。\n\n符号なしのオフセット量を入力してください。左右どちらへずらすかは、左右の実効フランジ距離の差が小さくなる方向へ自動的に適用されます。左右のフランジ距離が等しい場合、オフセットは計算に作用しません。\n\n単位: mm",
+        "ariaLabel": "リムオフセットのヘルプ"
       },
       "pcd": {
         "title": "PCD（ピッチ円直径）",
@@ -70,8 +77,10 @@
     "selectRequired": "選択してください",
     "invalidNumber": "数値を入力",
     "rangeErd": "1〜1000mm",
+    "rangeRimOffset": "0〜100mm",
     "rangeStandard": "1〜100mm",
     "rangeSpokeHole": "1.0〜3.0mm",
+    "rimOffsetTooLarge": "実効フランジ距離が0mm以下になります",
     "selectSpokeCount": "24/28/32/36",
     "selectCrossings": "0〜4を選択",
     "calculationUnavailable": "計算不可"

--- a/src/presets/Hope-Pro-5-CL_Nextie-Premium-2936_Front.json
+++ b/src/presets/Hope-Pro-5-CL_Nextie-Premium-2936_Front.json
@@ -4,6 +4,7 @@
   "description": "Front wheel preset for Hope Pro 5 CL hub with Nextie Premium 29x36 rim",
   "inputs": {
     "erd": "581",
+    "rimOffset": "0",
     "pitchCircleLeft": "43",
     "pitchCircleRight": "43",
     "flangeDistanceLeft": "27",

--- a/src/presets/Hope-Pro-5-CL_Nextie-Premium-2936_Rear.json
+++ b/src/presets/Hope-Pro-5-CL_Nextie-Premium-2936_Rear.json
@@ -4,6 +4,7 @@
   "description": "Rear wheel preset for Hope Pro 5 CL hub with Nextie Premium 29x36 rim",
   "inputs": {
     "erd": "581",
+    "rimOffset": "0",
     "pitchCircleLeft": "51",
     "pitchCircleRight": "59",
     "flangeDistanceLeft": "35",

--- a/src/presets/Hope-Pro-5-IS6_Nextie-Premium-2936_Front.json
+++ b/src/presets/Hope-Pro-5-IS6_Nextie-Premium-2936_Front.json
@@ -4,6 +4,7 @@
   "description": "Front wheel preset for Hope Pro 5 IS6 hub with Nextie Premium 29x36 rim",
   "inputs": {
     "erd": "581",
+    "rimOffset": "0",
     "pitchCircleLeft": "58",
     "pitchCircleRight": "52",
     "flangeDistanceLeft": "25",

--- a/src/presets/Hope-Pro-5-IS6_Nextie-Premium-2936_Rear.json
+++ b/src/presets/Hope-Pro-5-IS6_Nextie-Premium-2936_Rear.json
@@ -4,6 +4,7 @@
   "description": "Rear wheel preset for Hope Pro 5 IS6 hub with Nextie Premium 29x36 rim",
   "inputs": {
     "erd": "581",
+    "rimOffset": "0",
     "pitchCircleLeft": "57",
     "pitchCircleRight": "59",
     "flangeDistanceLeft": "35",


### PR DESCRIPTION
## 概要

- ERD の隣に、初期値 0 mm のリムオフセット入力を追加
- 左右のフランジ距離を比較し、実効 center-to-flange の差が小さくなる方向へオフセットを自動適用
- オフセット適用後の実効フランジ距離が正でない場合の検証エラーを追加
- 既存プリセット4件へオフセット 0 を明示
- リムオフセットを持たない旧localStorageデータと旧JSONを 0 として移行
- 日英のラベル、ヘルプ図・説明、検証文言、READMEを更新

## 検証

- pnpm lint
- pnpm build
- Playwrightによるデスクトップ・モバイル表示確認
- 日本語・英語、ライト・ダークモード確認
- 既存プリセットでオフセット 0 の計算結果が不変であることを確認
- 左フランジ距離が大きい場合と右フランジ距離が大きい場合の自動方向を確認
- 旧JSON読込、新JSON出力、旧localStorageデータ読込を確認
- 過大なオフセットで明示的な検証エラーが表示されることを確認

Closes #35
