### PR TITLE
入力フォームに視覚的グルーピングを導入

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -461,6 +461,26 @@ const FieldWarning: React.FC<{ id: string; message: string }> = ({ id, message }
   </p>
 );
 
+// Groups related input fields under a label, separated by a hairline rule.
+// The rule lives on the wrapper rather than on the fieldset itself: a bordered
+// fieldset gets a notch cut out of its top border where the legend sits.
+// `min-w-0` neutralises the fieldset UA default `min-inline-size: min-content`,
+// so a long unwrappable label can never push the form wider than its container.
+const FieldGroup: React.FC<{
+  label: string;
+  withRule?: boolean;
+  children: React.ReactNode;
+}> = ({ label, withRule = true, children }) => (
+  <div className={withRule ? 'border-t border-slate-200 dark:border-slate-700 pt-6' : undefined}>
+    <fieldset className="min-w-0">
+      <legend className="mb-3 text-sm font-semibold text-slate-700 dark:text-slate-200">
+        {label}
+      </legend>
+      <div className="space-y-4">{children}</div>
+    </fieldset>
+  </div>
+);
+
 // Regular number input component
 interface NumberInputProps {
   id: string;
@@ -1069,7 +1089,7 @@ const SpokeLengthCalculator: React.FC = () => {
         <div className="space-y-6">
           <h2 className="text-xl font-semibold text-slate-700 dark:text-slate-300 border-b border-slate-200 dark:border-slate-600 pb-2">{t('input.heading')}</h2>
 
-          <div className="space-y-4">
+          <div className="space-y-6">
             {/* Preset selection - only show if presets exist */}
             {presetOptions.length > 0 && (
               <div>
@@ -1089,221 +1109,231 @@ const SpokeLengthCalculator: React.FC = () => {
               </div>
             )}
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <div>
-                <div className="flex items-center gap-1 mb-1">
-                  <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">{t('input.erd')}</label>
-                  <HelpButton topic="erd" onOpen={setHelpTopic} />
+            {/* Without the preset block above, this rule would double up with the h2 border */}
+            <FieldGroup label={t('input.group.rim')} withRule={presetOptions.length > 0}>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div>
+                  <div className="flex items-center gap-1 mb-1">
+                    <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">{t('input.erd')}</label>
+                    <HelpButton topic="erd" onOpen={setHelpTopic} />
+                  </div>
+                  <NumberInput
+                    id="erd"
+                    value={inputs.erd}
+                    onChange={(value) => handleInputChange('erd', value)}
+                    onBlur={() => markFieldTouched('erd')}
+                    step={1}
+                    min={1}
+                    max={1000}
+                    error={visibleFieldErrors.erd}
+                    placeholder={t('input.erdPlaceholder')}
+                  />
+                  <FieldError id="erd-error" message={visibleFieldErrors.erd} />
                 </div>
-                <NumberInput
-                  id="erd"
-                  value={inputs.erd}
-                  onChange={(value) => handleInputChange('erd', value)}
-                  onBlur={() => markFieldTouched('erd')}
-                  step={1}
-                  min={1}
-                  max={1000}
-                  error={visibleFieldErrors.erd}
-                  placeholder={t('input.erdPlaceholder')}
-                />
-                <FieldError id="erd-error" message={visibleFieldErrors.erd} />
+                <div>
+                  <div className="flex items-center gap-1 mb-1">
+                    <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">{t('input.rimOffset')}</label>
+                    <HelpButton topic="rimOffset" onOpen={setHelpTopic} />
+                  </div>
+                  <NumberInput
+                    id="rimOffset"
+                    value={inputs.rimOffset}
+                    onChange={(value) => handleInputChange('rimOffset', value)}
+                    onBlur={() => markFieldTouched('rimOffset')}
+                    step={0.1}
+                    min={0}
+                    max={100}
+                    error={visibleFieldErrors.rimOffset}
+                    describedBy={rimOffsetWarning !== undefined ? 'rimOffset-warning' : undefined}
+                    placeholder={t('input.rimOffsetPlaceholder')}
+                  />
+                  {rimOffsetWarning !== undefined ? (
+                    <FieldWarning id="rimOffset-warning" message={rimOffsetWarning} />
+                  ) : (
+                    <FieldError id="rimOffset-error" message={visibleFieldErrors.rimOffset} />
+                  )}
+                </div>
               </div>
+            </FieldGroup>
+
+            <FieldGroup label={t('input.group.hub')}>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div>
+                  <div className="flex items-center gap-1 mb-1">
+                    <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">
+                      <span className="md:hidden">{t('input.pcdLeft')}</span>
+                      <span className="hidden md:block">{t('input.pcdLeft')}</span>
+                    </label>
+                    <HelpButton topic="pcd" onOpen={setHelpTopic} />
+                  </div>
+                  <NumberInput
+                    id="pitchCircleLeft"
+                    value={inputs.pitchCircleLeft}
+                    onChange={(value) => handleInputChange('pitchCircleLeft', value)}
+                    onBlur={() => markFieldTouched('pitchCircleLeft')}
+                    step={1}
+                    min={1}
+                    max={100}
+                    error={visibleFieldErrors.pitchCircleLeft}
+                    placeholder={t('input.flangeLeftPlaceholder')}
+                  />
+                  <FieldError id="pitchCircleLeft-error" message={visibleFieldErrors.pitchCircleLeft} />
+                </div>
+                <div>
+                  <div className="flex items-center gap-1 mb-1">
+                    <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">
+                      <span className="md:hidden">{t('input.pcdRight')}</span>
+                      <span className="hidden md:block">{t('input.pcdRight')}</span>
+                    </label>
+                    <HelpButton topic="pcd" onOpen={setHelpTopic} />
+                  </div>
+                  <NumberInput
+                    id="pitchCircleRight"
+                    value={inputs.pitchCircleRight}
+                    onChange={(value) => handleInputChange('pitchCircleRight', value)}
+                    onBlur={() => markFieldTouched('pitchCircleRight')}
+                    step={1}
+                    min={1}
+                    max={100}
+                    error={visibleFieldErrors.pitchCircleRight}
+                    placeholder={t('input.flangeRightPlaceholder')}
+                  />
+                  <FieldError id="pitchCircleRight-error" message={visibleFieldErrors.pitchCircleRight} />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div>
+                  <div className="flex items-center gap-1 mb-1">
+                    <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">{t('input.flangeDistanceLeft')}</label>
+                    <HelpButton topic="flangeDistance" onOpen={setHelpTopic} />
+                  </div>
+                  <NumberInput
+                    id="flangeDistanceLeft"
+                    value={inputs.flangeDistanceLeft}
+                    onChange={(value) => handleInputChange('flangeDistanceLeft', value)}
+                    onBlur={() => markFieldTouched('flangeDistanceLeft')}
+                    step={1}
+                    min={1}
+                    max={100}
+                    error={visibleFieldErrors.flangeDistanceLeft}
+                    placeholder={t('input.flangeLeftPlaceholder')}
+                  />
+                  <FieldError id="flangeDistanceLeft-error" message={visibleFieldErrors.flangeDistanceLeft} />
+                </div>
+                <div>
+                  <div className="flex items-center gap-1 mb-1">
+                    <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">{t('input.flangeDistanceRight')}</label>
+                    <HelpButton topic="flangeDistance" onOpen={setHelpTopic} />
+                  </div>
+                  <NumberInput
+                    id="flangeDistanceRight"
+                    value={inputs.flangeDistanceRight}
+                    onChange={(value) => handleInputChange('flangeDistanceRight', value)}
+                    onBlur={() => markFieldTouched('flangeDistanceRight')}
+                    step={1}
+                    min={1}
+                    max={100}
+                    error={visibleFieldErrors.flangeDistanceRight}
+                    placeholder={t('input.flangeRightPlaceholder')}
+                  />
+                  <FieldError id="flangeDistanceRight-error" message={visibleFieldErrors.flangeDistanceRight} />
+                </div>
+              </div>
+
               <div>
                 <div className="flex items-center gap-1 mb-1">
-                  <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">{t('input.rimOffset')}</label>
-                  <HelpButton topic="rimOffset" onOpen={setHelpTopic} />
+                  <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">{t('input.spokeHoleDiameter')}</label>
+                  <HelpButton topic="spokeHoleDiameter" onOpen={setHelpTopic} />
                 </div>
                 <NumberInput
-                  id="rimOffset"
-                  value={inputs.rimOffset}
-                  onChange={(value) => handleInputChange('rimOffset', value)}
-                  onBlur={() => markFieldTouched('rimOffset')}
+                  id="spokeHoleDiameter"
+                  value={inputs.spokeHoleDiameter}
+                  onChange={(value) => handleInputChange('spokeHoleDiameter', value)}
+                  onBlur={() => markFieldTouched('spokeHoleDiameter')}
                   step={0.1}
-                  min={0}
-                  max={100}
-                  error={visibleFieldErrors.rimOffset}
-                  describedBy={rimOffsetWarning !== undefined ? 'rimOffset-warning' : undefined}
-                  placeholder={t('input.rimOffsetPlaceholder')}
+                  min={1.0}
+                  max={3.0}
+                  error={visibleFieldErrors.spokeHoleDiameter}
+                  placeholder={t('input.spokeHolePlaceholder')}
                 />
-                {rimOffsetWarning !== undefined ? (
-                  <FieldWarning id="rimOffset-warning" message={rimOffsetWarning} />
-                ) : (
-                  <FieldError id="rimOffset-error" message={visibleFieldErrors.rimOffset} />
-                )}
+                <FieldError id="spokeHoleDiameter-error" message={visibleFieldErrors.spokeHoleDiameter} />
               </div>
-            </div>
+            </FieldGroup>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <FieldGroup label={t('input.group.lacing')}>
               <div>
-                <div className="flex items-center gap-1 mb-1">
-                  <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">
-                    <span className="md:hidden">{t('input.pcdLeft')}</span>
-                    <span className="hidden md:block">{t('input.pcdLeft')}</span>
-                  </label>
-                  <HelpButton topic="pcd" onOpen={setHelpTopic} />
-                </div>
-                <NumberInput
-                  id="pitchCircleLeft"
-                  value={inputs.pitchCircleLeft}
-                  onChange={(value) => handleInputChange('pitchCircleLeft', value)}
-                  onBlur={() => markFieldTouched('pitchCircleLeft')}
-                  step={1}
-                  min={1}
-                  max={100}
-                  error={visibleFieldErrors.pitchCircleLeft}
-                  placeholder={t('input.flangeLeftPlaceholder')}
-                />
-                <FieldError id="pitchCircleLeft-error" message={visibleFieldErrors.pitchCircleLeft} />
-              </div>
-              <div>
-                <div className="flex items-center gap-1 mb-1">
-                  <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">
-                    <span className="md:hidden">{t('input.pcdRight')}</span>
-                    <span className="hidden md:block">{t('input.pcdRight')}</span>
-                  </label>
-                  <HelpButton topic="pcd" onOpen={setHelpTopic} />
-                </div>
-                <NumberInput
-                  id="pitchCircleRight"
-                  value={inputs.pitchCircleRight}
-                  onChange={(value) => handleInputChange('pitchCircleRight', value)}
-                  onBlur={() => markFieldTouched('pitchCircleRight')}
-                  step={1}
-                  min={1}
-                  max={100}
-                  error={visibleFieldErrors.pitchCircleRight}
-                  placeholder={t('input.flangeRightPlaceholder')}
-                />
-                <FieldError id="pitchCircleRight-error" message={visibleFieldErrors.pitchCircleRight} />
-              </div>
-            </div>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <div>
-                <div className="flex items-center gap-1 mb-1">
-                  <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">{t('input.flangeDistanceLeft')}</label>
-                  <HelpButton topic="flangeDistance" onOpen={setHelpTopic} />
-                </div>
-                <NumberInput
-                  id="flangeDistanceLeft"
-                  value={inputs.flangeDistanceLeft}
-                  onChange={(value) => handleInputChange('flangeDistanceLeft', value)}
-                  onBlur={() => markFieldTouched('flangeDistanceLeft')}
-                  step={1}
-                  min={1}
-                  max={100}
-                  error={visibleFieldErrors.flangeDistanceLeft}
-                  placeholder={t('input.flangeLeftPlaceholder')}
-                />
-                <FieldError id="flangeDistanceLeft-error" message={visibleFieldErrors.flangeDistanceLeft} />
-              </div>
-              <div>
-                <div className="flex items-center gap-1 mb-1">
-                  <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">{t('input.flangeDistanceRight')}</label>
-                  <HelpButton topic="flangeDistance" onOpen={setHelpTopic} />
-                </div>
-                <NumberInput
-                  id="flangeDistanceRight"
-                  value={inputs.flangeDistanceRight}
-                  onChange={(value) => handleInputChange('flangeDistanceRight', value)}
-                  onBlur={() => markFieldTouched('flangeDistanceRight')}
-                  step={1}
-                  min={1}
-                  max={100}
-                  error={visibleFieldErrors.flangeDistanceRight}
-                  placeholder={t('input.flangeRightPlaceholder')}
-                />
-                <FieldError id="flangeDistanceRight-error" message={visibleFieldErrors.flangeDistanceRight} />
-              </div>
-            </div>
-
-            <div>
-              <div className="flex items-center gap-1 mb-1">
-                <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">{t('input.spokeHoleDiameter')}</label>
-                <HelpButton topic="spokeHoleDiameter" onOpen={setHelpTopic} />
-              </div>
-              <NumberInput
-                id="spokeHoleDiameter"
-                value={inputs.spokeHoleDiameter}
-                onChange={(value) => handleInputChange('spokeHoleDiameter', value)}
-                onBlur={() => markFieldTouched('spokeHoleDiameter')}
-                step={0.1}
-                min={1.0}
-                max={3.0}
-                error={visibleFieldErrors.spokeHoleDiameter}
-                placeholder={t('input.spokeHolePlaceholder')}
-              />
-              <FieldError id="spokeHoleDiameter-error" message={visibleFieldErrors.spokeHoleDiameter} />
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-slate-600 dark:text-slate-400 mb-1">{t('input.numberOfSpokes')}</label>
-              <select
-                id="numberOfSpokes"
-                value={inputs.numberOfSpokes}
-                onChange={(e) => handleInputChange('numberOfSpokes', e.target.value)}
-                onBlur={() => markFieldTouched('numberOfSpokes')}
-                aria-invalid={visibleFieldErrors.numberOfSpokes !== undefined}
-                aria-describedby={visibleFieldErrors.numberOfSpokes !== undefined ? 'numberOfSpokes-error' : undefined}
-                className={getControlClassName(visibleFieldErrors.numberOfSpokes !== undefined)}
-              >
-                <option value="">{t('input.selectOption')}</option>
-                <option value="24">24</option>
-                <option value="28">28</option>
-                <option value="32">32</option>
-                <option value="36">36</option>
-              </select>
-              <FieldError id="numberOfSpokes-error" message={visibleFieldErrors.numberOfSpokes} />
-            </div>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <div>
-                <div className="flex items-center gap-1 mb-1">
-                  <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">{t('input.crossingsLeft')}</label>
-                  <HelpButton topic="crossings" onOpen={setHelpTopic} />
-                </div>
+                <label className="block text-sm font-medium text-slate-600 dark:text-slate-400 mb-1">{t('input.numberOfSpokes')}</label>
                 <select
-                  id="crossingsLeft"
-                  value={inputs.crossingsLeft}
-                  onChange={(e) => handleInputChange('crossingsLeft', e.target.value)}
-                  onBlur={() => markFieldTouched('crossingsLeft')}
-                  aria-invalid={visibleFieldErrors.crossingsLeft !== undefined}
-                  aria-describedby={visibleFieldErrors.crossingsLeft !== undefined ? 'crossingsLeft-error' : undefined}
-                  className={getControlClassName(visibleFieldErrors.crossingsLeft !== undefined)}
+                  id="numberOfSpokes"
+                  value={inputs.numberOfSpokes}
+                  onChange={(e) => handleInputChange('numberOfSpokes', e.target.value)}
+                  onBlur={() => markFieldTouched('numberOfSpokes')}
+                  aria-invalid={visibleFieldErrors.numberOfSpokes !== undefined}
+                  aria-describedby={visibleFieldErrors.numberOfSpokes !== undefined ? 'numberOfSpokes-error' : undefined}
+                  className={getControlClassName(visibleFieldErrors.numberOfSpokes !== undefined)}
                 >
                   <option value="">{t('input.selectOption')}</option>
-                  <option value="0">{t('input.radialLacing')}</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
+                  <option value="24">24</option>
+                  <option value="28">28</option>
+                  <option value="32">32</option>
+                  <option value="36">36</option>
                 </select>
-                <FieldError id="crossingsLeft-error" message={visibleFieldErrors.crossingsLeft} />
+                <FieldError id="numberOfSpokes-error" message={visibleFieldErrors.numberOfSpokes} />
               </div>
-              <div>
-                <div className="flex items-center gap-1 mb-1">
-                  <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">{t('input.crossingsRight')}</label>
-                  <HelpButton topic="crossings" onOpen={setHelpTopic} />
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div>
+                  <div className="flex items-center gap-1 mb-1">
+                    <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">{t('input.crossingsLeft')}</label>
+                    <HelpButton topic="crossings" onOpen={setHelpTopic} />
+                  </div>
+                  <select
+                    id="crossingsLeft"
+                    value={inputs.crossingsLeft}
+                    onChange={(e) => handleInputChange('crossingsLeft', e.target.value)}
+                    onBlur={() => markFieldTouched('crossingsLeft')}
+                    aria-invalid={visibleFieldErrors.crossingsLeft !== undefined}
+                    aria-describedby={visibleFieldErrors.crossingsLeft !== undefined ? 'crossingsLeft-error' : undefined}
+                    className={getControlClassName(visibleFieldErrors.crossingsLeft !== undefined)}
+                  >
+                    <option value="">{t('input.selectOption')}</option>
+                    <option value="0">{t('input.radialLacing')}</option>
+                    <option value="1">1</option>
+                    <option value="2">2</option>
+                    <option value="3">3</option>
+                    <option value="4">4</option>
+                  </select>
+                  <FieldError id="crossingsLeft-error" message={visibleFieldErrors.crossingsLeft} />
                 </div>
-                <select
-                  id="crossingsRight"
-                  value={inputs.crossingsRight}
-                  onChange={(e) => handleInputChange('crossingsRight', e.target.value)}
-                  onBlur={() => markFieldTouched('crossingsRight')}
-                  aria-invalid={visibleFieldErrors.crossingsRight !== undefined}
-                  aria-describedby={visibleFieldErrors.crossingsRight !== undefined ? 'crossingsRight-error' : undefined}
-                  className={getControlClassName(visibleFieldErrors.crossingsRight !== undefined)}
-                >
-                  <option value="">{t('input.selectOption')}</option>
-                  <option value="0">{t('input.radialLacing')}</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                </select>
-                <FieldError id="crossingsRight-error" message={visibleFieldErrors.crossingsRight} />
+                <div>
+                  <div className="flex items-center gap-1 mb-1">
+                    <label className="block text-sm font-medium text-slate-600 dark:text-slate-400">{t('input.crossingsRight')}</label>
+                    <HelpButton topic="crossings" onOpen={setHelpTopic} />
+                  </div>
+                  <select
+                    id="crossingsRight"
+                    value={inputs.crossingsRight}
+                    onChange={(e) => handleInputChange('crossingsRight', e.target.value)}
+                    onBlur={() => markFieldTouched('crossingsRight')}
+                    aria-invalid={visibleFieldErrors.crossingsRight !== undefined}
+                    aria-describedby={visibleFieldErrors.crossingsRight !== undefined ? 'crossingsRight-error' : undefined}
+                    className={getControlClassName(visibleFieldErrors.crossingsRight !== undefined)}
+                  >
+                    <option value="">{t('input.selectOption')}</option>
+                    <option value="0">{t('input.radialLacing')}</option>
+                    <option value="1">1</option>
+                    <option value="2">2</option>
+                    <option value="3">3</option>
+                    <option value="4">4</option>
+                  </select>
+                  <FieldError id="crossingsRight-error" message={visibleFieldErrors.crossingsRight} />
+                </div>
               </div>
-            </div>
+            </FieldGroup>
+
+            {/* Closing rule for the input section */}
+            <div aria-hidden="true" className="border-t border-slate-200 dark:border-slate-700" />
           </div>
         </div>
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -25,6 +25,11 @@
     "crossingsLeft": "Crossings [L]",
     "crossingsRight": "Crossings [R]",
     "radialLacing": "0 (Radial Lacing)",
+    "group": {
+      "rim": "Rim",
+      "hub": "Hub",
+      "lacing": "Lacing"
+    },
     "help": {
       "erd": {
         "title": "ERD (Effective Rim Diameter)",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -25,6 +25,11 @@
     "crossingsLeft": "クロス [左]",
     "crossingsRight": "クロス [右]",
     "radialLacing": "0 (ラジアル組)",
+    "group": {
+      "rim": "リム",
+      "hub": "ハブ",
+      "lacing": "組み方"
+    },
     "help": {
       "erd": {
         "title": "ERD（有効リム径）",


### PR DESCRIPTION
Closes #40

## 概要

「入力値」セクションの 11 個のコントロールがフラットに並んでいたため、どのフィールドがリムの寸法でどれがハブの寸法なのか読み取れなかった。入力項目を **リム / ハブ / 組み方** の3グループに分割し、境界に控えめなヘアラインとグループ名を配置した。

区切り位置は issue の指定どおり以下の4箇所:

| # | 位置 | 実装 |
|---|---|---|
| 1 | プリセットの下 | 「リム」グループの上罫線 |
| 2 | リムオフセットの下 | 「ハブ」グループの上罫線 |
| 3 | スポーク穴直径の下 | 「組み方」グループの上罫線 |
| 4 | クロス[右]の下 | 入力セクションの締め罫線 |

## 変更内容

- `src/App.tsx`: `FieldGroup` コンポーネントを追加し、フォーム JSX を3グループに再構成
- `src/locales/ja.json` / `en.json`: `input.group.{rim,hub,lacing}` を追加

**フィールド自体（label / NumberInput / select / FieldError / HelpButton）は一切変更していない** — 移動と再インデントのみ。

## 設計判断

- **`<fieldset>` + `<legend>`** — 「PCD [左]/[右]」のような左右ペアがどの部位のものか、スクリーンリーダーにも伝わる
- **罫線は fieldset ではなくラッパー `<div>` に置く** — ボーダー付き fieldset は legend の位置で上ボーダーに切り欠き（notch）ができ、連続したヘアラインにならない
- **カードで囲わない** — 既存の「計算結果」カードと視覚的に競合させないため（card soup 回避）
- **`uppercase` を使わない** — 日本語では無効で ja/en 間で不整合になる。サイズではなくウェイトと色で階層を作った（h2 20px bold > グループ名 14px semibold > フィールドラベル 14px medium/muted）
- **プリセット非表示時の二重線回避** — プリセット読込失敗時（`alerts.presetLoadError`）にプリセット欄が消えるため、`withRule={presetOptions.length > 0}` でリムグループの罫線を抑制する

## 検証

- `pnpm lint` / `pnpm build` / `pnpm test`（7/7 pass）すべて通過
- スクリーンショット目視: デスクトップ 1440px / モバイル 375px × ライト/ダーク × ja/en
- **320px 幅で横スクロールなし** — `scrollWidth === clientWidth === 320`
- **DOM 検証**: 3つの fieldset が legend「リム」(2 controls) /「ハブ」(5 controls) /「組み方」(3 controls) を持ち、`borderTopWidth: 0px`（切り欠きなし）を確認
- **プリセット非表示ケース**: `presetOptions` を空にして再現し、リムグループのラッパーが罫線クラスを持たないこと（＝二重線が出ないこと）を確認

### 補足

`min-w-0` は fieldset の UA デフォルト `min-inline-size: min-content` への予防的な打ち消し。現在のラベル長では 320px でも実際にはオーバーフローしないことを確認済みだが、将来長いラベルが追加された際にレイアウトが静かに壊れるのを防ぐためのガードとして残している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)