### PR TITLE
カラースキーム刷新: zinc + blue から petrol へ

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@
     href="https://fonts.googleapis.com/css2?family=Inter:wght@400..700&family=Noto+Sans+JP:wght@400;500;600;700&display=swap"
     rel="stylesheet" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!-- --color-page と一致させる (zinc-50 / zinc-950)。ずれるとモバイルの
-       ブラウザクロームだけ別の色になる。 -->
-  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#fafafa" />
-  <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#09090b" />
+  <!-- src/index.css の --color-page と一致させる (petrol の oklch(0.985 0.006 205) /
+       oklch(0.150 0.018 205))。ずれるとモバイルのブラウザクロームだけ別の色になる。 -->
+  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f6fbfc" />
+  <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#030d0f" />
   <meta name="application-name" content="Spoke Length Calculator" />
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -8,8 +8,8 @@
   "scope": ".",
   "display": "standalone",
   "orientation": "any",
-  "background_color": "#f8fafc",
-  "theme_color": "#0f172a",
+  "background_color": "#f6fbfc",
+  "theme_color": "#030d0f",
   "categories": ["sports", "utilities"],
   "prefer_related_applications": false,
   "icons": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -733,7 +733,9 @@ const SpokeLengthCalculator: React.FC = () => {
     return [...presetItems, ...savedItems];
   }, [presetOptions, savedCalculations]);
 
-  const titleText = t(isCompactViewport ? 'titleShort' : 'title');
+  // タイトルは幅に関係なくフルで出す。375px でも折り返して収まり、
+  // ヘッダーは flex-col になるので h1 が単独行を占める。
+  const titleText = t('title');
   const resultsLeftText = t(isCompactViewport ? 'results.leftShort' : 'results.left');
   const resultsRightText = t(isCompactViewport ? 'results.rightShort' : 'results.right');
   const calculationNamePlaceholder = t(

--- a/src/components/CompareWheels.tsx
+++ b/src/components/CompareWheels.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown, CircleCheck, TriangleAlert } from 'lucide-react';
 import { compareWheels, type WheelSpec } from '../spokeCompare';
 import { nativeSelect, selectChevron } from '../styles';
 
@@ -106,8 +106,14 @@ const CompareWheels: React.FC<Props> = ({ options, selectedA, selectedB, onChang
             <p className="text-sm font-semibold text-fg mb-2">
               {t('compare.buyHeading')}
             </p>
+            {/* 以下 2 つのアイコンは装飾ではなく 1.4.1 の担保。ok / warn は
+                アクセントと色相を離してあるが、色だけで状態を伝えてはいけない。
+                組み方は App.tsx の FieldWarning に合わせている。 */}
             {result.buyItems.length === 0 ? (
-              <p className="text-sm text-ok-ink">{t('compare.noBuy')}</p>
+              <p className="flex items-start gap-1.5 text-sm text-ok-ink">
+                <CircleCheck aria-hidden="true" className="shrink-0 mt-0.5 h-4 w-4" />
+                <span>{t('compare.noBuy')}</span>
+              </p>
             ) : (
               <ul className="space-y-1">
                 {result.buyItems.map((item, i) => (
@@ -123,7 +129,10 @@ const CompareWheels: React.FC<Props> = ({ options, selectedA, selectedB, onChang
           </div>
 
           {result.reuseCount === 0 && result.buyItems.length > 0 && (
-            <p className="text-sm text-warn-ink">{t('compare.allNew')}</p>
+            <p className="flex items-start gap-1.5 text-sm text-warn-ink">
+              <TriangleAlert aria-hidden="true" className="shrink-0 mt-0.5 h-4 w-4" />
+              <span>{t('compare.allNew')}</span>
+            </p>
           )}
 
           {result.combinable && result.buyItems.length > 0 && (

--- a/src/index.css
+++ b/src/index.css
@@ -21,43 +21,72 @@
    下の .dark 上書きが無言で効かなくなる。素の @theme なら utility は
    var(--color-*) を参照するので、.dark で変数を差し替えるだけで一斉に切り替わる。
 
-   グレーは slate ではなく zinc。slate は青みがかっていて blue のアクセントを
-   濁らせるため。v4 の既定パレットは OKLCH なので var(--color-zinc-50) は
-   そのまま oklch に解決される。 */
+   配色は petrol (#44)。ニュートラルは色相 205 の青緑、アクセントは 203 の
+   深いペトロール。Tailwind の既定ランプに一致する色相が無いので
+   var(--color-zinc-*) のような参照は使えず oklch() リテラルで書く。
+   OKLCH が正で、行末の hex は目視用の参考値。
+
+   値はライト・ダーク両モードで本文 4.5:1 / 部品境界 3:1 / フォーカス 3:1 /
+   on-accent 4.5:1 を全ペアで満たすように選んである。個別の根拠は各所のコメント。 */
 @theme {
-  --color-page: var(--color-zinc-50);
+  --color-page: oklch(0.985 0.006 205);
+  /* #f6fbfc */
   --color-surface: #ffffff;
-  --color-sunken: var(--color-zinc-100);
-  --color-line: var(--color-zinc-200);
-  --color-line-strong: var(--color-zinc-300);
+  --color-sunken: oklch(0.966 0.012 205);
+  /* #ebf6f8 */
+  --color-line: oklch(0.918 0.020 205);
+  /* #d5e8ea */
+  /* line-strong は装飾罫線ではなく入力部品の境界 (getControlClassName /
+     nativeSelect / SegmentedControl)。WCAG 1.4.11 が 3:1 を要求するのでこの濃さに
+     なっている (3.27:1)。旧値 zinc-300 は 1.48:1 しかなかった。
+     「枠が濃い」という理由で薄く戻さないこと。 */
+  --color-line-strong: oklch(0.645 0.020 205);
+  /* #809193 */
 
-  --color-fg: var(--color-zinc-900);
-  --color-fg-muted: var(--color-zinc-600);
-  --color-fg-subtle: var(--color-zinc-500);
+  --color-fg: oklch(0.235 0.030 205);
+  /* #0a2225 */
+  --color-fg-muted: oklch(0.470 0.026 205);
+  /* #4a5f62 */
+  /* placeholder とタイムスタンプが載るので本文基準が要る。沈んだ面の上で 4.96:1。
+     旧値はライト/ダーク同値 (zinc-500) で、ダークの sunken 上では 3.08:1 だった。
+     ここは 2 モードで別の値を持つ。 */
+  --color-fg-subtle: oklch(0.520 0.024 205);
+  /* #596d6f */
 
-  --color-accent: var(--color-blue-600);
-  --color-accent-hover: var(--color-blue-700);
+  --color-accent: oklch(0.470 0.095 203);
+  /* #006a72 */
+  --color-accent-hover: oklch(0.415 0.098 203);
   --color-on-accent: #ffffff;
-  --color-accent-ink: var(--color-blue-700);
-  --color-accent-soft: var(--color-blue-50);
-  --color-accent-line: var(--color-blue-200);
-  --color-focus: var(--color-blue-600);
+  /* accent 上で 6.39:1 */
+  --color-accent-ink: oklch(0.440 0.098 203);
+  /* #00616a */
+  --color-accent-soft: oklch(0.965 0.020 203);
+  --color-accent-line: oklch(0.870 0.070 203);
+  --color-focus: var(--color-accent-ink);
 
-  --color-danger: var(--color-red-600);
-  --color-danger-ink: var(--color-red-600);
-  --color-danger-soft: var(--color-red-50);
-  --color-danger-line: var(--color-red-500);
+  --color-danger: oklch(0.545 0.215 27);
+  /* #d0121c */
+  --color-danger-hover: oklch(0.485 0.205 27);
+  --color-danger-ink: var(--color-danger);
+  --color-danger-soft: oklch(0.962 0.026 27);
+  /* danger-line だけは装飾枠ではなくエラー時の入力枠を兼ねる
+     (getControlClassName)。境界なので 3:1 が要り、ink と同値にしてある (5.54:1)。
+     warn-line / ok-line は装飾パネルの枠専用なので薄くてよい。 */
+  --color-danger-line: var(--color-danger-ink);
   --color-on-danger: #ffffff;
 
-  --color-warn-ink: var(--color-amber-700);
-  --color-warn-soft: var(--color-amber-50);
-  --color-warn-line: var(--color-amber-300);
+  --color-warn-ink: oklch(0.530 0.140 68);
+  --color-warn-soft: oklch(0.962 0.026 68);
+  --color-warn-line: oklch(0.855 0.070 68);
 
-  --color-ok-ink: var(--color-emerald-700);
-  --color-ok-soft: var(--color-emerald-50);
-  --color-ok-line: var(--color-emerald-200);
+  /* ok の色相を emerald (165) から 150 へ振った。アクセントが青緑 (203) なので
+     既定のままだと近すぎる。色相を離すだけでは不十分なので、ok / warn の
+     メッセージにはアイコンを添えてある (1.4.1: 色だけを情報伝達手段にしない)。 */
+  --color-ok-ink: oklch(0.505 0.115 150);
+  --color-ok-soft: oklch(0.962 0.026 150);
+  --color-ok-line: oklch(0.855 0.070 150);
 
-  --color-scrim: --alpha(var(--color-zinc-950) / 50%);
+  --color-scrim: --alpha(oklch(0.150 0.018 205) / 50%);
 
   /* Inter に CJK グリフは無いのでグリフ単位のフォールバックが働く:
      ラテンと数字は Inter、かな漢字と全角約物は Noto Sans JP。
@@ -83,43 +112,57 @@
 }
 
 .dark {
-  --color-page: var(--color-zinc-950);
-  --color-surface: var(--color-zinc-900);
-  --color-sunken: var(--color-zinc-800);
-  /* zinc-800 だと surface (zinc-900) との差が小さすぎて罫線が消える。
-     1 枚のシートをハイラインで区切る構成なので、ここが見えないと骨格が成立しない。 */
-  --color-line: var(--color-zinc-700);
-  --color-line-strong: var(--color-zinc-600);
+  --color-page: oklch(0.150 0.018 205);
+  /* #030d0f */
+  --color-surface: oklch(0.205 0.018 205);
+  /* #0d1a1b */
+  --color-sunken: oklch(0.268 0.018 205);
+  /* #1c292a */
+  /* surface との明度差が小さすぎると罫線が消える。1 枚のシートをハイラインで
+     区切る構成なので、ここが見えないと骨格が成立しない。 */
+  --color-line: oklch(0.368 0.024 205);
+  /* #304345 */
+  /* ライトと同じ理由で 3:1 が要る (3.49:1)。旧値 zinc-600 は 2.29:1 だった。 */
+  --color-line-strong: oklch(0.535 0.024 205);
+  /* #5d7274 */
 
-  --color-fg: var(--color-zinc-100);
-  --color-fg-muted: var(--color-zinc-400);
-  --color-fg-subtle: var(--color-zinc-500);
+  --color-fg: oklch(0.962 0.011 205);
+  /* #eaf5f6 */
+  --color-fg-muted: oklch(0.740 0.020 205);
+  /* #9dafb1 */
+  /* ライトの 0.520 とは別の値。沈んだ面の上で 4.89:1。 */
+  --color-fg-subtle: oklch(0.660 0.020 205);
+  /* #859698 */
 
-  /* on-accent が zinc-950 なのは白だと blue-500 上でコントラスト比 3.7:1 と
-     AA に届かないため。zinc-950 なら 6.5:1。 */
-  --color-accent: var(--color-blue-500);
-  --color-accent-hover: var(--color-blue-400);
-  --color-on-accent: var(--color-zinc-950);
-  --color-accent-ink: var(--color-blue-400);
-  --color-accent-soft: --alpha(var(--color-blue-500) / 12%);
-  --color-accent-line: var(--color-blue-900);
-  --color-focus: var(--color-blue-400);
+  /* on-accent が地の色なのは、明るいペトロールの上では白より濃い色のほうが
+     コントラストを稼げるため (8.72:1)。 */
+  --color-accent: oklch(0.735 0.105 199);
+  /* #45bdc2 */
+  --color-accent-hover: oklch(0.800 0.095 198);
+  --color-on-accent: var(--color-page);
+  --color-accent-ink: oklch(0.805 0.095 197);
+  /* #6dd2d4 */
+  --color-accent-soft: --alpha(oklch(0.735 0.105 199) / 14%);
+  --color-accent-line: oklch(0.430 0.090 199);
+  --color-focus: var(--color-accent-ink);
 
-  --color-danger: var(--color-red-500);
-  --color-danger-ink: var(--color-red-400);
-  --color-danger-soft: --alpha(var(--color-red-500) / 12%);
-  --color-danger-line: var(--color-red-500);
-  --color-on-danger: var(--color-zinc-950);
+  --color-danger: oklch(0.740 0.155 25);
+  /* #fe7f78 */
+  --color-danger-hover: oklch(0.800 0.140 25);
+  --color-danger-ink: var(--color-danger);
+  --color-danger-soft: --alpha(oklch(0.620 0.180 25) / 14%);
+  --color-danger-line: var(--color-danger-ink);
+  --color-on-danger: var(--color-page);
 
-  --color-warn-ink: var(--color-amber-300);
-  --color-warn-soft: --alpha(var(--color-amber-500) / 12%);
-  --color-warn-line: var(--color-amber-700);
+  --color-warn-ink: oklch(0.835 0.140 84);
+  --color-warn-soft: --alpha(oklch(0.620 0.180 84) / 14%);
+  --color-warn-line: oklch(0.430 0.090 84);
 
-  --color-ok-ink: var(--color-emerald-400);
-  --color-ok-soft: --alpha(var(--color-emerald-500) / 12%);
-  --color-ok-line: var(--color-emerald-800);
+  --color-ok-ink: oklch(0.800 0.130 152);
+  --color-ok-soft: --alpha(oklch(0.620 0.180 152) / 14%);
+  --color-ok-line: oklch(0.430 0.090 152);
 
-  --color-scrim: --alpha(var(--color-zinc-950) / 72%);
+  --color-scrim: --alpha(oklch(0.150 0.018 205) / 72%);
 }
 
 @layer base {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,6 +1,5 @@
 {
   "title": "Spoke Length Calculator",
-  "titleShort": "Spoke Length Calc",
   "input": {
     "heading": "Input Values",
     "preset": "Preset",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1,6 +1,5 @@
 {
   "title": "スポーク長計算機",
-  "titleShort": "スポーク長計算機",
   "input": {
     "heading": "入力値",
     "preset": "プリセット",

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -24,7 +24,7 @@ export const btnGhost =
   'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus';
 
 /** 破壊的動作。 */
-export const btnDanger = `${btnBase} bg-danger text-on-danger hover:brightness-110`;
+export const btnDanger = `${btnBase} bg-danger text-on-danger hover:bg-danger-hover`;
 
 // appearance-none はドロップダウンのポップアップまでは変えられない。
 // ポップアップ側は index.css の base 層にある color-scheme が担当する。


### PR DESCRIPTION
Closes #44

既定パレット由来の zinc + blue から、青緑ニュートラル (色相 205) + 深いペトロール (203) へ移行しました。#42 でトークン層に色を集約した結果、`src/index.css` の `@theme` と `.dark` を差し替えるだけで配色が丸ごと入れ替わり、`.tsx` 側の変更は 1 件だけで済んでいます。

## コントラスト不足の是正

配色の選択とは独立した既存の欠陥を 2 件直しました。

| ペア | 旧 | 新 | 要求 |
|---|---|---|---|
| `line-strong` / `surface` (ライト) | 1.48:1 | 3.27:1 | 3:1 (1.4.11) |
| `line-strong` / `surface` (ダーク) | 2.29:1 | 3.49:1 | 3:1 |
| `fg-subtle` / `sunken` (ダーク) | 3.08:1 | 4.89:1 | 4.5:1 (1.4.3) |

`line-strong` は `getControlClassName` / `nativeSelect` / `SegmentedControl` の枠、つまり入力部品の境界そのものです。`fg-subtle` は placeholder とタイムスタンプに使われています。

**入力枠が従来よりはっきり見えるようになるのは仕様です。** 「濃すぎる」という理由で薄く戻すと 1.4.11 を割ります。`index.css` にもその旨コメントを残しました。

`danger-line` も ink と同値に上げています。このトークンだけは装飾枠ではなくエラー時の入力枠を兼ねるためです。

新しい値はライト・ダーク両モードで本文 4.5:1 / 部品境界 3:1 / フォーカス 3:1 / on-accent 4.5:1 を全ペアで満たします。

## ok ロールにアイコンを追加

`ok` の色相を emerald (165) から 150 へ振りましたが、色相を離すだけでは不十分なので `CompareWheels` の noBuy (ok) と allNew (warn) にアイコンを足しました。この 2 つは色付きの `<p>` だけで状態を伝えており、1.4.1 に対する既存の欠陥でした。

## ついでに片付けたもの

- `public/manifest.webmanifest` の `background_color` / `theme_color` が slate 時代の値のまま取り残されていた (#42 の更新漏れ)
- `btnDanger` の hover だけ `hover:brightness-110` とフィルタでトークン層の外に出ていたので `--color-danger-hover` を新設
- モバイルのタイトル略称 `titleShort` を廃止。375px でも `Spoke Length Calculator` が 1 行に収まる

## スコープ外

別 issue に切るべきものとして残しています。

- `prefers-reduced-motion` 対応 (現状ゼロ)
- `forced-colors` / `prefers-contrast` 対応
- テーマの system (自動) 第3状態
- `theme-color` が `prefers-color-scheme` 依存で手動トグル時にずれる件

## 検証

- `pnpm lint` / `pnpm test` (7 pass) / `pnpm build` 通過。CSS 24.57 kB → 22.44 kB
- `rg "dark:" src/` とパレット直参照はいずれも 0 件のまま
- 実ページで `getComputedStyle(input).borderTopColor === oklch(0.645 0.02 205)` を確認
- 1440px / 375px、light / dark、ja / en で入力枠・placeholder・SegmentedControl・結果帯 (有効/無効)・リムオフセット警告・入力エラー・比較パネル・保存トースト・削除ダイアログ・HelpModal の SVG まで通した

🤖 Generated with [Claude Code](https://claude.com/claude-code)