### PR TITLE
feat(ui): スクロール中に計算結果を画面上部へ簡易表示

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Save, Trash2, FileJson, FileUp, Sun, Moon, TriangleAlert, ChevronDown, 
 import { useTranslation } from 'react-i18next';
 import { useToast } from './hooks/useToast';
 import { useTheme } from './hooks/useTheme';
+import { useIsVisible } from './hooks/useIsVisible';
 import { ConfirmDialog } from './components/ConfirmDialog';
 import { HelpButton } from './components/HelpButton';
 import { HelpModal, type HelpTopic } from './components/HelpModal';
@@ -466,6 +467,23 @@ const FieldWarning: React.FC<{ id: string; message: string }> = ({ id, message }
   </p>
 );
 
+// スクロール中プレビューの 1 セル。計算できない間は「—」を出す。
+// ピルごと消すのではなく値だけを置き換えるので、入力を打ち直している最中に
+// プレビューが出たり消えたりして視線が飛ばない。
+const ResultPreviewValue: React.FC<{ label: string; value?: number }> = ({ label, value }) => (
+  <div className="flex items-baseline gap-1.5 whitespace-nowrap">
+    <span className="text-xs font-medium text-fg-muted">{label}</span>
+    <span
+      className={[
+        'text-base font-semibold tabular-nums tracking-tight sm:text-lg',
+        value !== undefined ? 'text-accent-ink' : 'text-fg-subtle',
+      ].join(' ')}
+    >
+      {value !== undefined ? `${value.toFixed(1)} mm` : '— mm'}
+    </span>
+  </div>
+);
+
 const spokeCountSegments: SegmentedOption[] = spokeCountOptions.map(value => ({ value, label: value }));
 
 // セグメントには数字だけを描画する。375px では 5 分割で 1 セグメント約 60px しか
@@ -669,6 +687,8 @@ const SpokeLengthCalculator: React.FC = () => {
   const [touchedFields, setTouchedFields] = useState<TouchedFields>({});
   const savedCalculationsLoadedRef = useRef(false);
   const compareSectionRef = useRef<HTMLDivElement>(null);
+  const headerRef = useRef<HTMLElement>(null);
+  const resultsRef = useRef<HTMLDivElement>(null);
   const [showCompare, setShowCompare] = useState(false);
   const [compareA, setCompareA] = useState('');
   const [compareB, setCompareB] = useState('');
@@ -706,6 +726,16 @@ const SpokeLengthCalculator: React.FC = () => {
     })()
     : undefined;
   const hasValidResults = currentResults !== null;
+
+  // 入力フォームが縦に長く、上のフィールドを触っている間は結果帯が画面外に出る。
+  // その間だけ左右スポーク長を画面上部に浮かせる。「出さない」条件は 2 つ:
+  //   - 結果帯が見えている  … 同じ数値の二重表示になる
+  //   - ヘッダーが見えている … まだスクロールしていない。タイトルを覆ってしまう
+  // 比較パネルの開閉は条件に入れない。閉じずに上へスクロールしたときだけ
+  // プレビューが出ないのは、紛らわしさを避ける利より不具合に見える害が勝る。
+  const isHeaderVisible = useIsVisible(headerRef);
+  const areResultsVisible = useIsVisible(resultsRef);
+  const showResultPreview = !isHeaderVisible && !areResultsVisible;
 
   const wheelOptions = useMemo((): WheelOption[] => {
     const presetItems: WheelOption[] = presetOptions.map(p => ({
@@ -1088,7 +1118,10 @@ const SpokeLengthCalculator: React.FC = () => {
           セマンティクスと 1:1 で対応する機能的な区切り。旧 max-w-4xl より狭くし、
           モバイルは p-4 のままなので表示領域は失われない。 */}
       <div className="mx-auto w-full max-w-3xl px-4 py-6 sm:px-6 sm:py-8">
-        <header className="mb-8 flex flex-col gap-4 border-b border-line pb-5 sm:flex-row sm:items-center sm:justify-between">
+        <header
+          ref={headerRef}
+          className="mb-8 flex flex-col gap-4 border-b border-line pb-5 sm:flex-row sm:items-center sm:justify-between"
+        >
           <h1 className="text-2xl font-semibold tracking-tight text-fg sm:text-3xl">
             {titleText}
           </h1>
@@ -1370,6 +1403,7 @@ const SpokeLengthCalculator: React.FC = () => {
 
         {/* 結果はシート内の帯。角丸を持たせず、上のハイラインで区切る */}
         <div
+          ref={resultsRef}
           className={[
             'border-t p-5 transition-colors sm:p-6',
             currentResults !== null
@@ -1512,6 +1546,37 @@ const SpokeLengthCalculator: React.FC = () => {
           )}
         </div>
       </div>
+
+      {/* スクロール中の結果プレビュー。結果帯の複製なのでスクリーンリーダーには渡さない
+          (aria-hidden) —— 結果帯そのものが常に DOM にあり、二重読み上げは害でしかない。
+          pointer-events-none は下のフィールドのタップを塞がないため。
+          z-40 —— トーストとモーダル (z-50) の下に敷き、スクリム表示時は自然に沈む。 */}
+      {showResultPreview && (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none fixed inset-x-0 top-3 z-40 flex animate-fade-in-down justify-center px-4"
+        >
+          <div
+            className={[
+              'flex max-w-full items-center gap-4 rounded-full border px-4 py-2 shadow-lg transition-colors sm:gap-6',
+              currentResults !== null
+                ? 'bg-accent-soft border-accent-line'
+                : 'bg-sunken border-line',
+            ].join(' ')}
+          >
+            {/* 幅を取れないのでラベルはビューポートに関係なく短縮形。
+                値が無いときは「—」を置いてピルの幅と位置を保つ */}
+            <ResultPreviewValue
+              label={t('results.leftShort')}
+              value={currentResults?.left}
+            />
+            <ResultPreviewValue
+              label={t('results.rightShort')}
+              value={currentResults?.right}
+            />
+          </div>
+        </div>
+      )}
 
       {/* JSON data display modal */}
       {showJsonOutput && (

--- a/src/hooks/useIsVisible.ts
+++ b/src/hooks/useIsVisible.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState, type RefObject } from 'react';
+
+/**
+ * 要素がビューポートに少しでも掛かっているかを返す。
+ *
+ * スクロール量ではなく交差状態で判定するので、ヘッダー高さのような
+ * レイアウト定数を呼び出し側が抱えずに済む。
+ *
+ * 初期値は true —— observer の初回コールバックが届く前に呼び出し側が
+ * 「見えていない」と誤判定して、一瞬だけ要素を出してしまうのを防ぐ。
+ */
+export const useIsVisible = (ref: RefObject<Element | null>): boolean => {
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    const element = ref.current;
+
+    if (element === null) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(([entry]) => {
+      setIsVisible(entry.isIntersecting);
+    });
+
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return isVisible;
+};


### PR DESCRIPTION
Closes #46

## 背景

入力フォームが縦に長く、上のフィールドを触っている間は結果帯が画面外に出る。結果は `useMemo(() => getCalculationState(inputs), [inputs])` でキーストロークごとに再計算済みなのに、その更新を見るには毎回下までスクロールする必要があった。

## 変更内容

結果帯が画面外にある間だけ、左右スポーク長を画面上部の浮動ピルに表示する。

**「出さない」条件は 2 つ:**

- 結果帯が見えている —— 同じ数値の二重表示になる
- ヘッダーが見えている —— まだスクロールしていない。タイトルを覆ってしまう

比較パネルの開閉は当初は非表示条件に入れる予定だったが、**外した**。閉じずに上へスクロールしたときだけプレビューが出ないのは、紛らわしさを避ける利より不具合に見える害が勝るため。

## 設計上のポイント

- 判定は IntersectionObserver（新規 `src/hooks/useIsVisible.ts`）。結果帯は `overflow-hidden` を持つシート div の中にあり **`position: sticky` が効かない**（overflow ancestor が sticky containing block になりクリップされる）ため、ピルは `position: fixed` で置いた
- 計算できない間はピルごと消さず、値だけ `—` に置き換える。入力を打ち直している最中にプレビューが出入りして視線が飛ぶのを避ける
- 結果帯の複製なので `aria-hidden="true"`。結果帯そのものが常に DOM にあり、二重読み上げは害でしかない
- `pointer-events-none` で下のフィールドのタップを塞がない
- `z-40` でトースト・モーダル（z-50）の下に敷く。スクリム表示時は自然に沈む

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `src/hooks/useIsVisible.ts` | 新規（IntersectionObserver の薄いラッパ） |
| `src/App.tsx` | ref 2 本 + 導出値 + `ResultPreviewValue` + ピル JSX |

**新規翻訳キーは不要** —— `results.leftShort` / `results.rightShort` を再利用。`src/index.css` / `src/locales/*.json` / `src/styles.ts` は変更なし。既存の計算ロジックは一切触っていない。

## 検証

ブラウザ実機（375x812 / 375x450 / 1280x700、ライト・ダーク両方）で確認:

- ページ最上部: ピルが出ない（タイトルが隠れない）
- スクロールしてヘッダーが消えた時点: ピルがフェードイン。値が結果帯と一致（Left 290.7 / Right 289.8）
- さらにスクロールして結果帯が見えた時点: ピルが消える
- 比較パネルを開いたまま結果帯を画面外へ: ピルが出る（条件から外した挙動）
- ERD を空にする: ピルは残ったまま `Left — mm / Right — mm`、トーンが accent-soft から sunken に落ちる
- `document.elementFromPoint` でピル中央を叩くと下の `input[type=number]` が返る（`pointer-events-none` が効いている）

`pnpm tsc -b` / `pnpm lint` / `pnpm test`（7 pass）すべて green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
