### PR TITLE
fix(ui): ダークテーマで結果プレビュー (pill) を不透明化し視認性を改善

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1567,7 +1567,12 @@ const SpokeLengthCalculator: React.FC = () => {
           非表示時はヒットテストからも外れる。
           translate であって transform ではない: Tailwind v4 の translate-* は
           transform ではなく translate プロパティを吐くので、transform を並べても
-          何も動かない。 */}
+          何も動かない。
+
+          色は結果帯と同じ accent-soft / sunken ではなく overlay 系トークンを使う。
+          帯は不透明なシートに敷かれた面だがこれは本文の上に浮くので、ダークの
+          accent-soft (accent 14%) だと下の入力欄が透けて数値と衝突する (#52)。
+          overlay 系はライトでは帯と同値のエイリアスなので見た目は変わらない。 */}
       <div
         aria-hidden="true"
         className={[
@@ -1582,8 +1587,8 @@ const SpokeLengthCalculator: React.FC = () => {
           className={[
             'flex max-w-full items-center gap-4 rounded-full border px-4 py-2 shadow-lg transition-colors sm:gap-6',
             currentResults !== null
-              ? 'bg-accent-soft border-accent-line'
-              : 'bg-sunken border-line',
+              ? 'bg-overlay-accent border-overlay-accent-line'
+              : 'bg-overlay border-overlay-line',
           ].join(' ')}
         >
           {/* 幅を取れないのでラベルはビューポートに関係なく短縮形。

--- a/src/index.css
+++ b/src/index.css
@@ -88,6 +88,15 @@
 
   --color-scrim: --alpha(oklch(0.150 0.018 205) / 50%);
 
+  /* 本文の上に浮く要素の面 (スクロール中の結果プレビュー)。結果帯と同じ見え方を
+     狙うが、帯が不透明なシートの上に載るのに対しこちらは本文の上に浮くので、
+     accent-soft をそのまま使うと下の入力欄が透ける。ライトは accent-soft /
+     sunken が元から不透明なのでエイリアスで足り、.dark だけが実値を持つ。 */
+  --color-overlay-accent: var(--color-accent-soft);
+  --color-overlay-accent-line: var(--color-accent-line);
+  --color-overlay: var(--color-sunken);
+  --color-overlay-line: var(--color-line);
+
   /* Inter に CJK グリフは無いのでグリフ単位のフォールバックが働く:
      ラテンと数字は Inter、かな漢字と全角約物は Noto Sans JP。
      これで :lang(ja) 別指定が不要になる。
@@ -163,6 +172,20 @@
   --color-ok-line: oklch(0.430 0.090 152);
 
   --color-scrim: --alpha(oklch(0.150 0.018 205) / 72%);
+
+  /* ダークだけ実値を持つ。accent-soft (accent 14%) をシートの上で合成したときの
+     見えに合わせた不透明色で、L をわずかに上げて page から浮かせてある。
+     ここを透過にすると本文がプレビューの数値と重なって読めなくなる。 */
+  --color-overlay-accent: oklch(0.290 0.045 200);
+  /* #073234 —— accent-ink 7.80:1 / fg-muted 6.07:1 */
+  --color-overlay-accent-line: oklch(0.500 0.090 199);
+  /* #007277 —— page 上で 3.44:1 */
+  --color-overlay: oklch(0.290 0.018 205);
+  /* #212e30 —— fg-muted 6.14:1 / fg-subtle 4.55:1 */
+  /* 暗い地の上では shadow-lg (黒 10%) が効かないので、輪郭は罫線だけが担う。
+     素の line は page 比 2.09:1 で消えてしまう。line-strong は 3.86:1 あり、
+     浮遊チップの輪郭にそのまま使える。 */
+  --color-overlay-line: var(--color-line-strong);
 }
 
 @layer base {


### PR DESCRIPTION
Closes #52 / #49 (#46) の追加改善。

## 問題

スクロール中に画面上部へ出る結果プレビュー (pill) が、ダークテーマで下の本文と
衝突して読みづらい。

pill は結果帯 (`src/App.tsx:1409-1415`) と同じクラス対をそのまま使い回していた
(`src/App.tsx:1581-1587`) が、両者は置かれる場所が違う。

- **結果あり**: `bg-accent-soft` → ダークでは `--alpha(oklch(0.735 0.105 199) / 14%)`
  (`src/index.css:145`)。**86% 透過**。帯は不透明なシートの上に敷かれた「面」なので
  これで問題ないが、pill は `fixed` で本文の上に浮くため入力欄の文字・罫線がそのまま
  透けて数値と重なる
- **結果なし**: `bg-sunken` は不透明だが `--color-page` との明度差が 1.40:1 と小さく、
  `border-line` も page 比 2.09:1、`shadow-lg` は黒 10% で暗い地には効かないため
  輪郭がほぼ見えない

ライトモードは `--color-accent-soft` が元から不透明 (`src/index.css:63`) なので発生
しない ── ダーク固有の不具合。

## 変更

「本文の上に浮く要素の面」を意味する overlay 系トークンを追加し、**pill だけ**を
それに載せ替えた。

- ライトは `accent-soft` / `accent-line` / `sunken` / `line` のエイリアス
  → **ライトモードの見た目は変わらない**
- `.dark` だけが不透明値と強めの罫線を持つ
- `--color-accent-soft` 自体は変更していないので、結果帯と CompareWheels
  (`src/components/CompareWheels.tsx:86`) の tint は従来どおり
- `dark:` バリアント / パレット直参照 / `@theme inline` は使っていない (CLAUDE.md)

```diff
  currentResults !== null
-   ? 'bg-accent-soft border-accent-line'
-   : 'bg-sunken border-line',
+   ? 'bg-overlay-accent border-overlay-accent-line'
+   : 'bg-overlay border-overlay-line',
```

## 検証

`getComputedStyle` の解決済み色を canvas に塗ってピクセル読み戻しし、実 sRGB から
WCAG 比を実測 (Chrome は computed style で `oklch()` を `oklch()` のまま返すため)。
ダークで全ゲート通過:

| 前景 | 背景 | 実測 | 要求 |
|---|---|---|---|
| `accent-ink` (数値) | `overlay-accent` | 7.80:1 | >= 4.5 |
| `fg-muted` (ラベル) | `overlay-accent` | 6.07:1 | >= 4.5 |
| `fg-muted` (ラベル) | `overlay` | 6.14:1 | >= 4.5 |
| `fg-subtle` (`— mm`) | `overlay` | 4.55:1 | >= 4.5 |
| `overlay-accent-line` | `page` | 3.44:1 | >= 3 |
| `overlay-line` | `page` | 3.86:1 | >= 3 |

`fg-subtle` が 4.55:1 で足りたため、プレースホルダの色変更は不要だった。

その他:

- ダークで pill を入力欄に重ねて表示 → 透けなし (結果あり / なし 両方)。
  pill の computed `background-color` が alpha 1 であることも確認
- ライトでは pill の computed 値が結果帯と完全一致
  (`oklch(0.965 0.02 203)` / `oklch(0.87 0.07 203)`) ── 変更前と同一
- ダークで `accent-soft` が引き続き透過値であること (帯・比較パネル無変更) を確認
- `pnpm lint` / `pnpm build` / `pnpm test` (7 passed) 全て通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)