### PR TITLE
fix(ui): 結果プレビューのフェードをモバイルで知覚できる強度にする

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1560,14 +1560,27 @@ const SpokeLengthCalculator: React.FC = () => {
           pointer-events-none は下のフィールドのタップを塞がないため。
           z-40 —— トーストとモーダル (z-50) の下に敷き、スクリム表示時は自然に沈む。
 
-          条件付きマウントではなく常設し、opacity / translate の遷移で出し入れする。
-          アンマウントでは消えるほうが一瞬で終わり、出入りが非対称になるため。
+          条件付きマウントではなく常設し、opacity / translate / scale の遷移で
+          出し入れする。アンマウントでは消えるほうが一瞬で終わり、出入りが
+          非対称になるため。
           visibility も遷移対象に入れてある —— visible が絡む遷移では最後まで
           visible が保たれるので、フェードアウトを最後まで見せたうえで
           非表示時はヒットテストからも外れる。
-          translate であって transform ではない: Tailwind v4 の translate-* は
-          transform ではなく translate プロパティを吐くので、transform を並べても
-          何も動かない。
+          translate / scale であって transform ではない: Tailwind v4 の
+          translate-* と scale-* は transform ではなく個別プロパティを吐くので、
+          transform を並べても何も動かない。両方を transition-property に
+          列挙する必要がある。
+
+          移動量 16px + scale、入り 300ms / 出 200ms。旧値 (8px / 一律 200ms) は
+          小画面 (iPhone SE 3 等) の慣性スクロール中に知覚できなかった (#56)。
+          ヘッダーは文書頭から 130px ほどしかなく 1 回のフリックで画面外へ出るので、
+          境界の通過が速い。画面上端に張り付いた小さな要素では平行移動より
+          輪郭の変化のほうが強く読めるため scale を足し、origin-top で
+          下向きスライドと動きの向きを揃えてある。
+          duration / ease を条件分岐側に置いているのは意図的: 遷移開始時に参照される
+          transition-* は after-change style なので、状態と同時に切り替えれば
+          入り (ease-out で減速して着地) と出 (ease-in で加速して抜ける) に
+          別の時間とカーブを与えられる。
 
           色は結果帯と同じ accent-soft / sunken ではなく overlay 系トークンを使う。
           帯は不透明なシートに敷かれた面だがこれは本文の上に浮くので、ダークの
@@ -1576,11 +1589,11 @@ const SpokeLengthCalculator: React.FC = () => {
       <div
         aria-hidden="true"
         className={[
-          'pointer-events-none fixed inset-x-0 top-3 z-40 flex justify-center px-4',
-          'transition-[opacity,translate,visibility] duration-200 ease-out motion-reduce:transition-none',
+          'pointer-events-none fixed inset-x-0 top-3 z-40 flex origin-top justify-center px-4',
+          'transition-[opacity,translate,scale,visibility] motion-reduce:transition-none',
           showResultPreview
-            ? 'visible translate-y-0 opacity-100'
-            : 'invisible -translate-y-2 opacity-0',
+            ? 'visible translate-y-0 scale-100 opacity-100 duration-300 ease-out'
+            : 'invisible -translate-y-4 scale-95 opacity-0 duration-200 ease-in',
         ].join(' ')}
       >
         <div


### PR DESCRIPTION
Closes #56

## 現象

スクロール中に左右スポーク長を画面上部へ浮かせる結果プレビュー（ピル）の出入りが、
iPhone SE 3 / iPhone 16e の実機で弱く短く感じられる。デスクトップでは認識できる。

## 原因

機能不全ではなく効果量の不足。旧設定は移動量 `-translate-y-2` = **8px**、
時間 **一律 200ms**、出入りとも同一カーブだった。

小画面ではヘッダーが文書頭から 130px ほどしかなく（実測 136.7px / 375x667）、
1 回のフリックで即座に画面外へ出る。境界の通過が速いので、視線が入力欄にある
状態では 200ms / 8px の変化がほぼ知覚されない。デスクトップのホイールスクロールは
境界通過が遅いので気づける、という差だった。
加えて、画面上端に張り付いた小さな要素では 8px の平行移動は輪郭をほとんど変えない。

## 変更

| 項目 | 旧 | 新 |
| --- | --- | --- |
| 移動量 | 8px | **16px** |
| scale | なし | **0.95 -> 1**（`origin-top`） |
| 入り | 200ms `ease-out` | **300ms `ease-out`** |
| 出 | 200ms `ease-out` | **200ms `ease-in`** |

- `duration` / `ease` を条件分岐側へ移した。CSS Transitions 仕様では遷移開始時に
  参照される `transition-*` は after-change style なので、状態と同時に切り替えれば
  方向ごとに別の時間とカーブを与えられる。
- `scale` は `translate` と同じく Tailwind v4 が個別プロパティを吐くため、
  `transition-property` への明記が必要（既存コメントの `translate` の説明と同じ事情）。
- `origin-top` は全幅ラッパーに掛かるが `transform-origin: top` = `50% 0%` で
  水平方向は中央基準。中央寄せされたピルは自分自身の中心を軸に縮む（実測
  `transform-origin: 187.5px 0px` / ピル中心 188px）。内側 div へ状態を二重化していない。

### 入れなかったもの

- `will-change`: 症状はカクつきではなく「弱い」。opacity / transform 系の遷移は
  開始時に自動でレイヤー昇格されるため、常設の合成レイヤーを抱える対価に見合わない。
- `motion-reduce:transition-none` は据え置き。今回の症状は「フェードはする」なので
  reduced-motion は効いておらず、触ると診断が濁る。

## 検証

375x667（iPhone SE 3 相当）で実際に遷移をフレームサンプリングし、両方向とも
設計どおりに動くことを確認した。

**入り（300ms / ease-out）**

| t (ms) | opacity | translate | scale | visibility |
| --- | --- | --- | --- | --- |
| 1 | 0 | -16px | 0.95 | hidden |
| 188 | 0.908 | -1.47px | 0.995 | visible |
| 254 | 0.985 | -0.25px | 0.999 | visible |
| 322 | 1 | 0 | 1 | visible |

**出（200ms / ease-in）**

| t (ms) | opacity | translate | scale | visibility |
| --- | --- | --- | --- | --- |
| 23 | 1 | 0 | 1 | visible |
| 83 | 0.837 | -2.61px | 0.992 | visible |
| 166 | 0.371 | -10.07px | 0.969 | **visible** |
| 233 | 0 | -16px | 0.95 | hidden |

出では opacity が 0.371 の時点でも `visibility: visible` が保たれ、遷移完了後に
`hidden` へ落ちている。`visibility` を遷移対象に含める既存の設計どおり。

その他:

- ビルド後 CSS で `transition-property: opacity,translate,scale,visibility` /
  `origin-top` / `scale-95` / `scale-100` / `-translate-y-4` / `duration-300` /
  `ease-in` がすべて生成されていることを確認
- 375x667 のライト / ダーク両方で、フェード途中フレーム（opacity 0.70）と
  完了状態をレンダリング確認。中央から外れず、上端の見切れも無し
- 結果あり（数値表示）/ なし（`— mm`）の両方で確認
- `pnpm lint` / `pnpm build` / `pnpm test`（7 pass）すべて通過

**実機確認をお願いします**（iPhone SE 3 / iPhone 16e）。エミュレーションでは
iOS の慣性スクロールと Safari のツールバー伸縮が再現されません。

## 残課題（本 PR では実装しない）

実機でまだ「途中で切れる」ように見えた場合: iOS Safari は下部ツールバーが
スクロールで畳まれビューポート高が約 50px 変わる。これが
`useIsVisible(resultValuesRef, 0.99)` の 0.99 境界を跨がせ `showResultPreview` が
往復して遷移がキャンセルされている可能性がある。その場合は観測側に `rootMargin` に
よるデッドバンドを入れる。投機的には入れていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)