### PR TITLE
fix(ui): ドック中の結果帯の干渉低減と変形の高速化

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { Save, Trash2, FileJson, FileUp, Sun, Moon, TriangleAlert, ChevronDown, 
 import { useTranslation } from 'react-i18next';
 import { useToast } from './hooks/useToast';
 import { useTheme } from './hooks/useTheme';
-import { useDockProgress } from './hooks/useDockProgress';
+import { useDockMorph } from './hooks/useDockMorph';
 import { ConfirmDialog } from './components/ConfirmDialog';
 import { HelpButton } from './components/HelpButton';
 import { HelpModal, type HelpTopic } from './components/HelpModal';
@@ -467,33 +467,82 @@ const FieldWarning: React.FC<{ id: string; message: string }> = ({ id, message }
   </p>
 );
 
-// 結果帯の 2 つの姿。progress 0 が本来の姿、1 が簡易表示で、間はすべて線形補間。
+// 結果帯の 2 つの姿。--dock 0 が本来の姿、1 が簡易表示で、間はすべて線形補間。
 // 数値は現行の Tailwind クラスの実寸をそのまま px にしたもの:
 //   pad        … p-5 / p-6
 //   headingLine… 見出し (text-sm) の行高
 //   headingGap … 見出しの mb-4
 //   gridMin    … 数値グリッドの min-h-24 / sm:min-h-20
+//   labelLine  … ラベルの行高。クラスではなくインラインで持つ (下の ResultBandValue 参照)
 //   label      … text-sm / sm:text-base
 //   value      … text-2xl / sm:text-3xl
 // クラスではなくインラインの数値で持つのは、中間値がユーティリティの
 // スケール上に存在しないため。補間する以上リテラルにするしかない。
-const BAND_FULL_NARROW = { pad: 20, headingLine: 20, headingGap: 16, gridMin: 96, label: 14, value: 24 };
-const BAND_FULL_WIDE = { pad: 24, headingLine: 20, headingGap: 16, gridMin: 80, label: 16, value: 30 };
+const BAND_FULL_NARROW = { pad: 20, headingLine: 20, headingGap: 16, gridMin: 96, labelLine: 20, label: 14, value: 24 };
+const BAND_FULL_WIDE = { pad: 24, headingLine: 20, headingGap: 16, gridMin: 80, labelLine: 20, label: 16, value: 30 };
 
-// 簡易表示。画面下端に貼り付くので、見出しと余白を畳んで数値だけを残す。
+// 簡易表示。画面下端に貼り付くので、見出しもラベルも畳んで数値だけを残す。
 // 横の余白 (pad) は畳まない —— 数値の x 座標が動くと「同じものが縮んだ」
 // ではなく「別のものに入れ替わった」に見えてしまう。
-const BAND_COMPACT = { pad: 12, headingLine: 0, headingGap: 0, gridMin: 0, label: 12, value: 18 };
+//
+// gridMin を 0 ではなく実値で持つのは、これが簡易表示の高さを決めているから。
+// 数値だけの行の実寸 (value 18px × leading-tight = 22.5px) を上回る値にして、
+// 高さが全区間で gridMin 側で決まるようにしてある。こうすると帯の高さが --dock の
+// 一次関数になり、DOCK_ABSORB で変形距離を詰めても不変条件を保てる。
+// 逆にここが 0 のままだと高さは折れ線になり、着地直前の変化率が跳ね上がる。
+//
+// label は簡易表示のプレースホルダ (結果がまだ無いときの一文) のためだけに使う。
+// ラベル自体の文字サイズは補間しない —— 畳んで見えないので意味がない。
+const BAND_COMPACT = { pad: 10, headingLine: 0, headingGap: 0, gridMin: 26, labelLine: 0, label: 12, value: 18 };
+
+// 簡易表示の高さ。border-t の 1px は両方の姿に共通なので変形量には入らない
+const BAND_COMPACT_HEIGHT =
+  BAND_COMPACT.pad * 2 + BAND_COMPACT.headingLine + BAND_COMPACT.headingGap + BAND_COMPACT.gridMin;
+
+// 帯がスクロールを吸収する割合。1 未満でなければならない ——
+// 1 では帯が縮む速さと隙間が広がる速さが釣り合い、変形中ずっと「本来の下端が
+// 画面下端にぴったり」の境界に乗る。1 を超えると帯のほうが速く縮み、変形の途中で
+// sticky から解放されて画面下端を離れてしまう (簡易表示が本文と一緒に浮き上がる)。
+// 小さくすると変形はゆっくりになり、ドック中に入力欄を覆う量が増える。
+const DOCK_ABSORB = 0.9;
+
+// --dock を 0..1 の補間係数として使う calc()。スクロール中に動くのは --dock だけなので、
+// React はこの文字列を初回に置くだけでよく、再描画は起きない。
+// フォールバックの 1 は「JS がまだ書き込む前は簡易表示」を意味する。
+const dockPx = (from: number, to: number): string => {
+  const delta = to - from;
+
+  return `calc(${from}px ${delta < 0 ? '-' : '+'} ${Math.abs(delta)}px * var(--dock, 1))`;
+};
+
+const dockFadeIn = 'calc(1 - var(--dock, 1))';
+
+// 帯の姿の寸法と、ドック度合いを測るための 2 つの距離。
+const bandMetrics = (isCompactViewport: boolean) => {
+  const full = isCompactViewport ? BAND_FULL_NARROW : BAND_FULL_WIDE;
+  // 本来の姿での高さ。これを基準に食み出し量を測ることで、姿が戻りきる瞬間と
+  // sticky がドックを解除する瞬間が一致する
+  const fullHeight = full.pad * 2 + full.headingLine + full.headingGap + full.gridMin;
+  // 帯が縮むことで吸収する量
+  const travel = fullHeight - BAND_COMPACT_HEIGHT;
+
+  return { full, fullHeight, travel, morphSpan: travel / DOCK_ABSORB };
+};
 
 // 計算結果の帯。シート内の 1 区画でありながら、まだそこまでスクロールして
 // いない間は画面下端にドックして簡易表示になる。
 //
 // 重ねた別要素ではなく「帯そのものが変形する」ことが要点。position: sticky で
-// 帯自身を画面下端に留め、見出し・余白・文字サイズを progress で線形補間して
+// 帯自身を画面下端に留め、見出し・ラベル・余白・文字サイズを --dock で線形補間して
 // 縮める。だから利用者が見ているものは常に 1 つで、簡易表示と本来の姿の間に
 // 乗り換えの瞬間が無い。控えを重ねる実装 (#58 初版) はこれを満たさなかった:
 // 別々の 2 つがクロスフェードすると「上に何か出てきた」としか読めない。
 // 横の余白と 2 分割グリッドは畳まないので、数値の x 座標は変形中も動かない。
+//
+// 補間は React ではなく CSS の calc() が行う (#60)。値はシート div の --dock に
+// フックが直接書き込むので、この style 文字列はビューポート幅にしか依存せず、
+// スクロール中の再描画は 0 回になる。連続値をそのまま使えるので、量子化と
+// それを均すための transition が要らない = スクロールに 1:1 で追従する。
 //
 // sticky が効くのはシート div から overflow-hidden を外したため。あれが付いて
 // いるとシート自身がスクロールコンテナ扱いになり、中の sticky は「決して
@@ -502,10 +551,14 @@ const BAND_COMPACT = { pad: 12, headingLine: 0, headingGap: 0, gridMin: 0, label
 // z-10 —— ドック中は上の入力欄に重なるので、その上に出す。トースト (z-50) や
 // モーダル (z-50) より下。
 // pointer-events はドック中だけ切る。入力欄の上に浮いている間はタップを
-// 塞がないため。本来の位置に着地したら通常どおり選択できる。
+// 塞がないため。本来の位置に着地したら通常どおり選択できる。ドック中かどうかは
+// シートの data-docked で伝わる (数値の --dock では pointer-events を表せない)。
+//
+// transition は色だけに残す。結果が出た瞬間の面の色替えとテーマ切替はここが担うが、
+// 寸法に効かせるとスクロールへの追従が遅れる。
 //
 // aria-hidden は付けない —— 控えを重ねていた頃は二重読み上げを避けるために
-// 必要だったが、今は要素が 1 つしかない。見出しも display:none ではなく
+// 必要だったが、今は要素が 1 つしかない。見出しもラベルも display:none ではなく
 // max-height と opacity で畳むので、支援技術からは常に読める。
 //
 // 色は accent-soft / sunken ではなく overlay 系トークン。ドック中は本文の上に
@@ -513,34 +566,31 @@ const BAND_COMPACT = { pad: 12, headingLine: 0, headingGap: 0, gridMin: 0, label
 // 衝突する (#52)。ライトでは元の値へのエイリアスなので見た目は変わらない。
 const ResultBand: React.FC<{
   slotTopRef: RefObject<Element | null>;
+  scopeRef: RefObject<HTMLElement | null>;
   results: Results | null;
   heading: string;
   placeholder: string;
   leftLabel: string;
   rightLabel: string;
   isCompactViewport: boolean;
-}> = ({ slotTopRef, results, heading, placeholder, leftLabel, rightLabel, isCompactViewport }) => {
-  const full = isCompactViewport ? BAND_FULL_NARROW : BAND_FULL_WIDE;
-  // 本来の姿での高さ。これを useDockProgress に渡すことで、姿が戻りきる瞬間と
-  // sticky がドックを解除する瞬間が一致する
-  const fullHeight = full.pad * 2 + full.headingLine + full.headingGap + full.gridMin;
-  const progress = useDockProgress(slotTopRef, fullHeight);
-  const lerp = (from: number, to: number): number => from + (to - from) * progress;
+}> = ({ slotTopRef, scopeRef, results, heading, placeholder, leftLabel, rightLabel, isCompactViewport }) => {
+  const { full, fullHeight, morphSpan } = bandMetrics(isCompactViewport);
+
+  useDockMorph(slotTopRef, scopeRef, fullHeight, morphSpan);
 
   return (
     <div
       style={{
-        paddingTop: `${lerp(full.pad, BAND_COMPACT.pad)}px`,
+        paddingTop: dockPx(full.pad, BAND_COMPACT.pad),
         // 下端にドックしている間はホームインジケータを避ける。畳んだ余白より
         // セーフエリアのほうが大きい端末では、そちらが下限になる
-        paddingBottom: `max(${lerp(full.pad, BAND_COMPACT.pad)}px, env(safe-area-inset-bottom, 0px))`,
+        paddingBottom: `max(${dockPx(full.pad, BAND_COMPACT.pad)}, env(safe-area-inset-bottom, 0px))`,
         paddingLeft: `${full.pad}px`,
         paddingRight: `${full.pad}px`,
       }}
       className={[
-        'sticky bottom-0 z-10 border-t transition-all duration-100 ease-linear',
-        'motion-reduce:transition-none',
-        progress > 0 ? 'pointer-events-none' : '',
+        'sticky bottom-0 z-10 border-t transition-colors',
+        'group-data-[docked]:pointer-events-none',
         results !== null
           ? 'bg-overlay-accent border-overlay-accent-line'
           : 'bg-overlay border-overlay-line',
@@ -550,27 +600,27 @@ const ResultBand: React.FC<{
           読み上げ順からは外れない */}
       <h2
         style={{
-          maxHeight: `${lerp(full.headingLine, BAND_COMPACT.headingLine)}px`,
-          marginBottom: `${lerp(full.headingGap, BAND_COMPACT.headingGap)}px`,
-          opacity: 1 - progress,
+          maxHeight: dockPx(full.headingLine, BAND_COMPACT.headingLine),
+          marginBottom: dockPx(full.headingGap, BAND_COMPACT.headingGap),
+          opacity: dockFadeIn,
         }}
-        className="overflow-hidden text-sm font-medium text-fg-muted transition-all duration-100 ease-linear motion-reduce:transition-none"
+        className="overflow-hidden text-sm font-medium text-fg-muted"
       >
         {heading}
       </h2>
       <div
-        style={{ minHeight: `${lerp(full.gridMin, BAND_COMPACT.gridMin)}px` }}
-        className="grid w-full grid-cols-2 items-center gap-3 text-center transition-all duration-100 ease-linear motion-reduce:transition-none sm:gap-4"
+        style={{ minHeight: dockPx(full.gridMin, BAND_COMPACT.gridMin) }}
+        className="grid w-full grid-cols-2 items-center gap-3 text-center sm:gap-4"
       >
         {results !== null ? (
           <>
-            <ResultBandValue label={leftLabel} value={results.left} full={full} lerp={lerp} />
-            <ResultBandValue label={rightLabel} value={results.right} full={full} lerp={lerp} />
+            <ResultBandValue label={leftLabel} value={results.left} full={full} />
+            <ResultBandValue label={rightLabel} value={results.right} full={full} />
           </>
         ) : (
           <p
-            style={{ fontSize: `${lerp(full.label, BAND_COMPACT.label)}px` }}
-            className="col-span-2 text-fg-subtle transition-all duration-100 ease-linear motion-reduce:transition-none"
+            style={{ fontSize: dockPx(full.label, BAND_COMPACT.label) }}
+            className="col-span-2 text-fg-subtle"
           >
             {placeholder}
           </p>
@@ -580,25 +630,35 @@ const ResultBand: React.FC<{
   );
 };
 
-// 帯の 1 セル。ラベルと数値の積み方は変えず、文字サイズだけを補間する ——
-// 縦積みと横並びを切り替えると、その瞬間だけ別のレイアウトが割り込んで
-// 「変形」に見えなくなる。
+// 帯の 1 セル。ラベルと数値の積み方は変えない —— 縦積みと横並びを切り替えると、
+// その瞬間だけ別のレイアウトが割り込んで「変形」に見えなくなる。
+// 簡易表示ではラベルを見出しと同じ作法で畳み、数値だけを残す。ドックしている帯が
+// 入力欄を覆う量はこの高さで決まるので、畳めるものは畳む (#60)。
 const ResultBandValue: React.FC<{
   label: string;
   value: number;
   full: typeof BAND_FULL_NARROW;
-  lerp: (from: number, to: number) => number;
-}> = ({ label, value, full, lerp }) => (
+}> = ({ label, value, full }) => (
   <div>
     <h3
-      style={{ fontSize: `${lerp(full.label, BAND_COMPACT.label)}px` }}
-      className="font-medium text-fg-muted transition-all duration-100 ease-linear motion-reduce:transition-none"
+      style={{
+        // 文字サイズは補間しない。畳んで見えなくなるので意味がなく、
+        // 毎フレームのテキスト再シェイプを 2 ノードぶん節約できる。
+        fontSize: `${full.label}px`,
+        // 行高をインラインで持つのは、畳む基準の labelLine と実寸を一致させるため。
+        // クラス (text-sm / sm:text-base) 由来の行高だと 20px / 24px と食い違い、
+        // 本来の姿でラベルが 4px 切り落とされる
+        lineHeight: `${full.labelLine}px`,
+        maxHeight: dockPx(full.labelLine, BAND_COMPACT.labelLine),
+        opacity: dockFadeIn,
+      }}
+      className="overflow-hidden font-medium text-fg-muted"
     >
       {label}
     </h3>
     <p
-      style={{ fontSize: `${lerp(full.value, BAND_COMPACT.value)}px` }}
-      className="font-semibold leading-tight tabular-nums tracking-tight text-accent-ink transition-all duration-100 ease-linear motion-reduce:transition-none"
+      style={{ fontSize: dockPx(full.value, BAND_COMPACT.value) }}
+      className="font-semibold leading-tight tabular-nums tracking-tight text-accent-ink"
     >
       {value.toFixed(1)} mm
     </p>
@@ -811,6 +871,9 @@ const SpokeLengthCalculator: React.FC = () => {
   // 結果帯の直前の要素。帯は sticky で自分の位置から自分の状態を決められないので、
   // ドック度合いはこの下端 (= 帯の本来の上端) を測って決める
   const inputSectionRef = useRef<HTMLDivElement>(null);
+  // ドック度合い (--dock) の書き込み先。帯だけでなくシート内の兄弟にも継承させたいので、
+  // 帯自身ではなくシートに置く
+  const sheetRef = useRef<HTMLDivElement>(null);
   const [showCompare, setShowCompare] = useState(false);
   const [compareA, setCompareA] = useState('');
   const [compareB, setCompareB] = useState('');
@@ -1270,8 +1333,10 @@ const SpokeLengthCalculator: React.FC = () => {
             overflow-hidden は付けない —— 付けるとこの div がスクロールコンテナに
             なり、中の結果帯の position: sticky が効かなくなる。子は入力欄・
             結果帯・保存欄の 3 つで、背景を持つのは中央の結果帯だけなので、
-            角丸のクリップは元々不要 */}
-        <div className="rounded-xl border border-line bg-surface">
+            角丸のクリップは元々不要。
+            group と ref はドック度合いのため —— --dock と data-docked をここに書き、
+            結果帯は group-data-[docked]: で受ける */}
+        <div ref={sheetRef} className="group rounded-xl border border-line bg-surface">
           {/* Input section */}
           <div ref={inputSectionRef} className="space-y-6 p-5 sm:p-6">
             <h2 className="text-xl font-semibold text-fg border-b border-line pb-2">{t('input.heading')}</h2>
@@ -1520,6 +1585,7 @@ const SpokeLengthCalculator: React.FC = () => {
             まだそこまでスクロールしていない間は画面下端にドックして縮む */}
         <ResultBand
           slotTopRef={inputSectionRef}
+          scopeRef={sheetRef}
           results={currentResults}
           heading={t('results.heading')}
           placeholder={t('results.placeholder')}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -574,59 +574,66 @@ const ResultBand: React.FC<{
   rightLabel: string;
   isCompactViewport: boolean;
 }> = ({ slotTopRef, scopeRef, results, heading, placeholder, leftLabel, rightLabel, isCompactViewport }) => {
-  const { full, fullHeight, morphSpan } = bandMetrics(isCompactViewport);
+  const { full, fullHeight, travel, morphSpan } = bandMetrics(isCompactViewport);
 
   useDockMorph(slotTopRef, scopeRef, fullHeight, morphSpan);
 
   return (
-    <div
-      style={{
-        paddingTop: dockPx(full.pad, BAND_COMPACT.pad),
-        // 下端にドックしている間はホームインジケータを避ける。畳んだ余白より
-        // セーフエリアのほうが大きい端末では、そちらが下限になる
-        paddingBottom: `max(${dockPx(full.pad, BAND_COMPACT.pad)}, env(safe-area-inset-bottom, 0px))`,
-        paddingLeft: `${full.pad}px`,
-        paddingRight: `${full.pad}px`,
-      }}
-      className={[
-        'sticky bottom-0 z-10 border-t transition-colors',
-        'group-data-[docked]:pointer-events-none',
-        results !== null
-          ? 'bg-overlay-accent border-overlay-accent-line'
-          : 'bg-overlay border-overlay-line',
-      ].join(' ')}
-    >
-      {/* 見出しは畳むだけで消さない。overflow-hidden + max-height なので
-          読み上げ順からは外れない */}
-      <h2
-        style={{
-          maxHeight: dockPx(full.headingLine, BAND_COMPACT.headingLine),
-          marginBottom: dockPx(full.headingGap, BAND_COMPACT.headingGap),
-          opacity: dockFadeIn,
-        }}
-        className="overflow-hidden text-sm font-medium text-fg-muted"
-      >
-        {heading}
-      </h2>
+    <>
       <div
-        style={{ minHeight: dockPx(full.gridMin, BAND_COMPACT.gridMin) }}
-        className="grid w-full grid-cols-2 items-center gap-3 text-center sm:gap-4"
+        style={{
+          paddingTop: dockPx(full.pad, BAND_COMPACT.pad),
+          // 下端にドックしている間はホームインジケータを避ける。畳んだ余白より
+          // セーフエリアのほうが大きい端末では、そちらが下限になる
+          paddingBottom: `max(${dockPx(full.pad, BAND_COMPACT.pad)}, env(safe-area-inset-bottom, 0px))`,
+          paddingLeft: `${full.pad}px`,
+          paddingRight: `${full.pad}px`,
+        }}
+        className={[
+          'sticky bottom-0 z-10 border-t transition-colors',
+          'group-data-[docked]:pointer-events-none',
+          results !== null
+            ? 'bg-overlay-accent border-overlay-accent-line'
+            : 'bg-overlay border-overlay-line',
+        ].join(' ')}
       >
-        {results !== null ? (
-          <>
-            <ResultBandValue label={leftLabel} value={results.left} full={full} />
-            <ResultBandValue label={rightLabel} value={results.right} full={full} />
-          </>
-        ) : (
-          <p
-            style={{ fontSize: dockPx(full.label, BAND_COMPACT.label) }}
-            className="col-span-2 text-fg-subtle"
-          >
-            {placeholder}
-          </p>
-        )}
+        {/* 見出しは畳むだけで消さない。overflow-hidden + max-height なので
+            読み上げ順からは外れない */}
+        <h2
+          style={{
+            maxHeight: dockPx(full.headingLine, BAND_COMPACT.headingLine),
+            marginBottom: dockPx(full.headingGap, BAND_COMPACT.headingGap),
+            opacity: dockFadeIn,
+          }}
+          className="overflow-hidden text-sm font-medium text-fg-muted"
+        >
+          {heading}
+        </h2>
+        <div
+          style={{ minHeight: dockPx(full.gridMin, BAND_COMPACT.gridMin) }}
+          className="grid w-full grid-cols-2 items-center gap-3 text-center sm:gap-4"
+        >
+          {results !== null ? (
+            <>
+              <ResultBandValue label={leftLabel} value={results.left} full={full} />
+              <ResultBandValue label={rightLabel} value={results.right} full={full} />
+            </>
+          ) : (
+            <p
+              style={{ fontSize: dockPx(full.label, BAND_COMPACT.label) }}
+              className="col-span-2 text-fg-subtle"
+            >
+              {placeholder}
+            </p>
+          )}
+        </div>
       </div>
-    </div>
+      {/* 帯が縮んだぶんを埋める。帯 + ここの合計が常に fullHeight になるので、変形中も
+          シート以下・文書全体・スクロール可能範囲の高さが変わらない。再レイアウトは帯の
+          内部に閉じ、保存欄や比較パネルの再配置とスクロール範囲の再計算が消える。
+          ドック中は帯の本来の下端が必ず画面下端より下にあるので、ここが見えることはない */}
+      <div aria-hidden="true" style={{ height: dockPx(0, travel) }} />
+    </>
   );
 };
 

--- a/src/hooks/useDockMorph.ts
+++ b/src/hooks/useDockMorph.ts
@@ -1,11 +1,4 @@
-import { useLayoutEffect, useState, type RefObject } from 'react';
-
-// 量子化の刻み。連続値をそのまま state に入れるとフレームごとに再描画が走る。
-// 0.02 なら帯 1 つぶんの通過 (約 170px) 全体で最大 50 回。残る段差は
-// 呼び出し側の短い transition が均す。
-// 端点にきっちり落ちることも保証する —— 0.004 が残ると「本来の姿に戻り
-// きらない帯」ができ、ドック解除の瞬間に僅かなずれとして見える。
-const STEP = 0.02;
+import { useLayoutEffect, type RefObject } from 'react';
 
 const clamp01 = (value: number): number => Math.min(1, Math.max(0, value));
 
@@ -21,42 +14,72 @@ const getViewportBottom = (): number => {
 };
 
 /**
- * 画面下端にドックしている度合いを 0..1 で返す。
+ * 画面下端にドックしている度合いを、CSS カスタムプロパティ `--dock` (0..1) として
+ * `scopeRef` の要素に書き込む。
  *   1 … 帯の居場所がまだ折り返しの下 (ドック中 = 簡易表示)
  *   0 … 帯の居場所が画面内に収まった (本来の姿)
+ * ドック中は `data-docked` 属性も立てる。pointer-events は数値で表せないため。
+ *
+ * 値を返さず DOM に直接書くのが要点。state に入れるとスクロールのフレームごとに
+ * React の再描画が走る。書き込み先では補間を calc() で行うので、React が置くのは
+ * 初回の style 文字列だけになり、スクロール中の再描画は 0 回になる。連続値のまま
+ * 扱えるので量子化も CSS トランジションも要らず、変形はスクロールに 1:1 で追従する。
  *
  * 測るのは帯そのものではなく `slotTopRef` —— 帯は position: sticky なので
  * getBoundingClientRect() が「引き上げられた後」の位置を返し、自分の位置から
  * 自分の状態を決められない。帯の直前にある要素 (入力セクション) の下端が
  * 帯の本来の上端なので、そちらを測ると sticky の影響を受けない。
  *
- * `distance` には帯の本来の高さを渡す。これにより progress が 0 になる瞬間と
- * sticky がドックを解除する瞬間 (帯の本来の下端が画面内に入る瞬間) が一致し、
+ * `fullHeight` は帯の本来の高さ。食み出し量をこれを基準に出すので、progress が 0 に
+ * なる瞬間と sticky がドックを解除する瞬間 (帯の本来の下端が画面内に入る瞬間) が一致し、
  * 姿が戻りきると同時に帯が流れの中へ着地する。
+ * `morphSpan` はその食み出し量を 0..1 に写すときの分母 = 変形が完了するまでの
+ * スクロール距離。fullHeight より短くすれば変形は速くなるが、帯の高さの変化量
+ * (fullHeight - 簡易表示の高さ) を下回ってはならない —— 下回ると帯は隙間が広がるより
+ * 速く縮み、変形の途中で sticky から解放されて画面下端を離れてしまう。
  */
-export const useDockProgress = (
+export const useDockMorph = (
   slotTopRef: RefObject<Element | null>,
-  distance: number,
-): number => {
-  const [progress, setProgress] = useState(1);
-
+  scopeRef: RefObject<HTMLElement | null>,
+  fullHeight: number,
+  morphSpan: number,
+): void => {
   useLayoutEffect(() => {
     const element = slotTopRef.current;
+    const scope = scopeRef.current;
 
-    if (element === null || distance <= 0) {
+    if (element === null || scope === null || morphSpan <= 0) {
       return;
     }
 
     let frame = 0;
+    let docked: boolean | null = null;
 
     const update = () => {
       frame = 0;
 
-      // 帯の本来の上端。ここから distance ぶん下が本来の下端になる
+      // 帯の本来の上端。ここから fullHeight ぶん下が本来の下端になる
       const slotTop = element.getBoundingClientRect().bottom;
-      const overflow = slotTop - getViewportBottom() + distance;
+      const overflow = slotTop - getViewportBottom() + fullHeight;
+      const progress = clamp01(overflow / morphSpan);
 
-      setProgress(Math.round(clamp01(overflow / distance) / STEP) * STEP);
+      scope.style.setProperty('--dock', progress.toFixed(4));
+
+      // 属性の変更はセレクタの再マッチを伴うので、変わった瞬間だけ触る。
+      // 解除は removeAttribute でなければならない —— [data-docked] は属性の
+      // 存在で一致するので、'false' を入れると着地後もドック中の扱いが残り、
+      // 帯とその下のコントロールが永久にタップできなくなる。
+      const isDocked = progress > 0;
+
+      if (isDocked !== docked) {
+        docked = isDocked;
+
+        if (isDocked) {
+          scope.setAttribute('data-docked', '');
+        } else {
+          scope.removeAttribute('data-docked');
+        }
+      }
     };
 
     const schedule = () => {
@@ -90,7 +113,5 @@ export const useDockProgress = (
       window.visualViewport?.removeEventListener('scroll', schedule);
       resizeObserver.disconnect();
     };
-  }, [slotTopRef, distance]);
-
-  return progress;
+  }, [slotTopRef, scopeRef, fullHeight, morphSpan]);
 };

--- a/src/index.css
+++ b/src/index.css
@@ -199,6 +199,13 @@
     border-color: var(--color-line);
   }
 
+  /* 画面下端にドックしている結果帯 (簡易表示で 47px) の裏にフォーカスが潜らないように。
+     Tab 移動と Android のソフトキーボードで、ブラウザが自動スクロールする先を押し上げる。
+     値の出所は App.tsx の BAND_COMPACT。 */
+  html {
+    scroll-padding-bottom: 3rem;
+  }
+
   /* v4 の preflight は button の cursor を default にする。v3 の挙動に戻す。 */
   button:not(:disabled),
   [role="button"]:not(:disabled) {


### PR DESCRIPTION
## 概要

Closes #60

PR #59 の「帯そのものが変形する」方針を保ったまま、残っていた 2 点を直す。

### 1. 最後の入力欄との干渉低減 (66px → 47px)

簡易表示で見出しに続いて左右のラベルも `max-height` + `opacity` で畳み、数値だけを残す。
`display:none` にしないので支援技術からは読める。余白のリザーブはしない (選択のとおり)。

`BAND_COMPACT.gridMin` を 0 から実値 26px にしたのは、これが簡易表示の高さを決めているから。
数値だけの行の実寸 22.5px を上回る値にすると帯の高さが `--dock` の一次関数になり、3 の距離短縮が
可能になる。**この 2 つは分離できない** —— `gridMin` の明示だけを入れると着地直前の変化率が緩み、
覆う量が逆に増える。

`html` に `scroll-padding-bottom` を追加し、Tab 移動とソフトキーボードの自動スクロールが帯の裏に
フォーカスを置かないようにする。

### 2. スクロール追従の遅れの除去

`progress` を 0.02 刻みに量子化して state に入れ、段差を `transition-all duration-100` で均す設計を
やめる。フックはシート div の `--dock` に連続値を直接書き、補間は `calc()` が行う。

- スクロール中の React 再描画が **0 回**になる (style 文字列はビューポート幅にしか依存しない)
- 量子化とトランジションが不要になり、変形がスクロールに **1:1 で追従** (遅れ 0・段差 0)
- 毎フレームのテキスト再シェイプが 4 ノード → 2 ノード
- 帯 + スペーサーの合計を常に `fullHeight` に保ち、変形中に文書全体の高さが変わらないようにする
  (変更前は 126px 変動していた)

iPhone SE 3 で遅れが目立ち他機ではほぼ問題なかったのは、375px 幅が `gridMin: 96` の最も背の高い
構成で、変形量と再レイアウト範囲が最大になるため。

### 3. 変形距離の短縮 (172px → 140px, 1.23 倍速)

`DOCK_ABSORB = 0.9` を導入し、変形完了までのスクロール距離を帯の高さの変化量から決める。
**1 以上にはできない** —— 帯が隙間の広がりより速く縮み、変形の途中で sticky から解放されて
画面下端を離れてしまう。確認時に提示した 130px から 140px に緩めたのは、1 で簡易表示を薄くした
結果この余裕が 3% (覆う量 4px = 測定誤差の範囲) しか残らなくなったため。薄型化と距離短縮は
トレードオフで、上限は `fullHeight / (fullHeight - 簡易表示の高さ)` = 1.37 倍。

## 実装

- `src/hooks/useDockProgress.ts` → `src/hooks/useDockMorph.ts` (契約が変わるのでリネーム)。
  `--dock` と `data-docked` をシート div に書き、値は返さない。解除は必ず `removeAttribute` ——
  `[data-docked]` は属性の存在で一致するので `'false'` を入れると帯とその下のコントロールが
  永久にタップできなくなる
- `src/App.tsx`: 帯の寸法に `labelLine` を追加、`BAND_COMPACT_HEIGHT` / `DOCK_ABSORB` /
  `bandMetrics()` を追加、補間を `dockPx()` の `calc()` 化、シートに `group` と ref、帯の直後に
  スペーサー
- `src/index.css`: `@layer base` に `html { scroll-padding-bottom: 3rem }`

スペーサー (2 の最後の項目) は独立したコミットにしてある。1・3 と遅れ除去は実測された原因への
対処だが、こちらは「文書高の変動が SE 3 の重さに効いている」という仮説に基づくため、切り分けと
撤回ができるようにした。

## Test plan

- [x] `pnpm lint` / `pnpm build` / `pnpm test`
- [x] Playwright で幾何アサーション (375x667 / 900x800)
  - `--dock` が 4px 刻みのスクロールで毎回異なる値になる (量子化の消滅を確認: 61 サンプルで
    34〜36 の異なる値)
  - `--dock > 0` の全地点で帯の下端が画面下端に一致 (ずれ最大 0px) —— ドック維持の不変条件
  - 着地地点で帯の上端と入力セクションの下端が一致 (`border-t` の 1px 以内)
  - 簡易表示の高さ 47px、セル実寸 22.5px < `gridMin` 26px —— 高さが一次関数である前提の実測
  - 変形中に入力欄を覆う量は最大 14.6px
  - `--dock` 0.49 の位置で入力値を変えても `--dock` が保たれる (React の再描画で消えない)
  - `scrollHeight` と保存欄の文書座標がスクロール位置によらず一定、スペーサーは常に画面外
  - 375 ⇄ 900 を変形の途中で切り替えても `--dock` と寸法が整合する (帯 + スペーサー = 173px)
- [x] スクリーンショット目視 (375px, ライト/ダーク, 5 つのスクロール位置): 数値の x 座標が
      動かないこと、ダークでドック中の帯が不透明で下の入力欄が透けないこと、着地後に帯と保存欄の
      間に余分な隙間や二重罫線が出ないこと
- [ ] **iPhone SE 3 実機での確認 (依頼)** —— 遅れが体感で解消したかどうか。これが受け入れ基準で、
      当方では実施できない。残る場合の対処 (帯の箱の高さを固定し、背景と `transform` だけで
      見た目を作るレイアウトを伴わない方式) は別 issue に切る想定で、この PR の修正では扱わない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLnyWo1dwyVrDCw32e5sVV
