### PR TITLE
chore: Lucideのライセンス通知を配布物へ同梱する

### DIFF
--- a/public/THIRD_PARTY_NOTICES.txt
+++ b/public/THIRD_PARTY_NOTICES.txt
@@ -1,0 +1,15 @@
+ISC License
+
+Copyright (c) for portions of Lucide are held by Cole Bemis 2013-2022 as part of Feather (MIT). All other copyright (c) for Lucide are held by Lucide Contributors 2022.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/src/thirdPartyNotices.test.ts
+++ b/src/thirdPartyNotices.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const noticeUrl = new URL('../public/THIRD_PARTY_NOTICES.txt', import.meta.url);
+const lucideLicenseUrl = new URL(
+  '../node_modules/lucide-react/LICENSE',
+  import.meta.url,
+);
+
+test('keeps the distributed Lucide notice in sync with the installed license', async () => {
+  const [notice, lucideLicense] = await Promise.all([
+    readFile(noticeUrl),
+    readFile(lucideLicenseUrl),
+  ]);
+
+  assert.deepEqual(notice, lucideLicense);
+});


### PR DESCRIPTION
## 概要
- public/THIRD_PARTY_NOTICES.txt に lucide-react@0.525.0 の ISC ライセンス全文を追加
- インストール済みパッケージの LICENSE との完全一致を検証する node:test を追加
- Vite ビルド後の dist に通知ファイルが同梱されることを確認

## 検証
- pnpm lint
- pnpm test
- pnpm build
- public・node_modules・dist の通知ファイルの SHA-256 一致確認

Closes #68