### PR TITLE
fix(ui): ホイール比較パネル展開時の自動スクロールを復旧する

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import {
   ArrowLeftRight,
   ChevronDown,
@@ -1188,6 +1188,12 @@ const SpokeLengthCalculator: React.FC = () => {
     setTouchedFields(prev => ({ ...prev, [field]: true }));
   };
 
+  useLayoutEffect(() => {
+    if (showCompare) {
+      compareSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [showCompare]);
+
   useEffect(() => {
     if (typeof window === 'undefined') {
       return;
@@ -1316,14 +1322,6 @@ const SpokeLengthCalculator: React.FC = () => {
   const cancelDelete = () => {
     setShowDeleteConfirm(false);
     setCalculationToDelete(null);
-  };
-
-  const handleCompareToggle = () => {
-    if (!showCompare) {
-      compareSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-
-    setShowCompare(prev => !prev);
   };
 
   // JSON export
@@ -1857,7 +1855,7 @@ const SpokeLengthCalculator: React.FC = () => {
           {/* APG の disclosure —— 見出しの中にボタン。input.heading と同格の h2 */}
           <h2>
             <button
-              onClick={handleCompareToggle}
+              onClick={() => setShowCompare(prev => !prev)}
               aria-expanded={showCompare}
               aria-controls="compare-panel"
               className={`w-full min-h-11 flex items-center justify-between gap-3 px-5 sm:px-6 py-4 text-left text-lg font-semibold text-fg hover:bg-sunken transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus ${showCompare ? 'rounded-t-xl border-b border-line' : 'rounded-xl'}`}


### PR DESCRIPTION
## 概要
- ホイール比較パネル展開時のスクロールを、展開前のクリックハンドラからDOMコミット後の `useLayoutEffect` へ戻しました。
- 閉じる操作ではスクロールを実行せず、既存のARIA disclosure、アニメーション、比較UIを維持します。

## 根本原因
PR #71 で `scrollIntoView` が `setShowCompare` より前へ移動していました。比較カードは文書末尾にあるため、展開前は既に最大スクロール位置で呼び出しが 0px にクランプされます。その後パネル展開で増えたスクロール範囲には処理が再実行されず、全ブラウザで自動スクロールが見えなくなっていました。

## 検証
- `pnpm lint`
- `pnpm test`（8件成功）
- `pnpm build`
- `git diff --check`
- `git ls-files --eol src/App.tsx`（i/lf, w/lf）
- Playwrightの事前自動スクロールを避けた座標クリックで、以下のビューポートを数値確認
  - Desktop 1440x900: scrollY 803 → 990
  - Pixel 9 Pro相当 412x915: scrollY 1241 → 1506
  - iPhone SE 3 375x667: scrollY 1489 → 1774
  - iPhone 16e相当 390x844: scrollY 1312 → 1597
- 全条件で展開後の新しい最大スクロール位置へ到達
- 全条件で閉じるときの追加スクロールなし
- ブラウザコンソールの新規エラー・警告なし

Closes #72