### PR TITLE
feat(preset): ハブ / リム単体のプリセットを追加 (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ Most of the code in this project was created with [Claude Code](https://claude.a
 ## Features
 
 - **Precise spoke length calculation**: Uses common formulas combining cosine rule (planar) and Pythagorean theorem (3D)
-- **Preset functionality**: Select from author-owned hub/rim combinations
-  - Hope Pro 5 IS6 + Nextie Premium 2936 (Front/Rear)
+- **Presets**: Fill the form from author-owned parts, picked from the chips next to each section heading
+  - Whole wheel: Hope Pro 5 CL / IS6 hubs paired with Nextie Premium 2936 or Stan's Flow MK4 (front/rear)
+  - Hub only / rim only: pick a hub and a rim separately to work out a wheel that has never been built
+  - The chips mirror the current inputs — pick a wheel and the hub/rim chips light up on their own;
+    edit a field by hand and the chips that no longer match go quiet
 - **Rich input parameters**:
   - ERD (Effective Rim Diameter)
   - Rim offset (automatically applied to reduce the effective left/right flange-distance difference)
@@ -72,7 +75,8 @@ text renders in Inter rather than a fallback face.
 ## Usage
 
 1. **Enter basic information**
-   - **Preset selection**: Choose from hub/rim combinations (optional)
+   - **Presets** (optional): use the chip beside "Input Values" for a whole wheel, or the chips
+     beside the Rim / Hub headings to fill just that section
    - Input various dimensions for rim and hub
    - Select number of spokes and lacing pattern
 
@@ -100,6 +104,8 @@ text renders in Inter rather than a fallback face.
 │   ├── i18n.ts                    # Internationalization configuration
 │   ├── rimOffset.ts               # Rim offset logic
 │   ├── rimOffset.test.ts          # Rim offset unit tests
+│   ├── partPresets.ts             # Hub / rim part preset loading and matching
+│   ├── presetData.test.ts         # Keeps whole-wheel presets in sync with the parts
 │   ├── spokeCompare.ts            # Wheel comparison logic
 │   ├── vite-env.d.ts              # Vite environment types
 │   ├── assets/                    # Static assets
@@ -109,6 +115,7 @@ text renders in Inter rather than a fallback face.
 │   │   ├── ConfirmDialog.tsx      # Confirmation dialog
 │   │   ├── HelpButton.tsx         # Inline help trigger
 │   │   ├── HelpModal.tsx          # Help modal with SVG diagrams
+│   │   ├── PresetSelect.tsx       # Preset picker (CSS customizable select)
 │   │   ├── SegmentedControl.tsx   # Segmented radio group
 │   │   └── Toast.tsx              # Toast notification component
 │   ├── contexts/                  # React contexts
@@ -122,13 +129,10 @@ text renders in Inter rather than a fallback face.
 │   ├── locales/                   # Translation files
 │   │   ├── en.json                # English translations
 │   │   └── ja.json                # Japanese translations
-│   └── presets/                   # Preset data (6 files)
-│       ├── Hope-Pro-5-CL_Nextie-Premium-2936_Front.json
-│       ├── Hope-Pro-5-CL_Nextie-Premium-2936_Rear.json
-│       ├── Hope-Pro-5-IS6_Nextie-Premium-2936_Front.json
-│       ├── Hope-Pro-5-IS6_Nextie-Premium-2936_Rear.json
-│       ├── Hope-Pro-5-IS6_Stans-Flow-MK4_Front.json
-│       └── Hope-Pro-5-IS6_Stans-Flow-MK4_Rear.json
+│   └── presets/                   # Preset data
+│       ├── *.json                 # Whole wheel: {hub}_{rim}_{Front|Rear}.json (6 files)
+│       ├── hubs/                  # Hub only: {hub}_{Front|Rear}.json (4 files)
+│       └── rims/                  # Rim only: {rim}.json (2 files)
 ├── public/                        # Static files
 │   └── calculator.svg
 ├── dist/                          # Build output

--- a/README_ja.md
+++ b/README_ja.md
@@ -17,8 +17,11 @@ GitHub pages: https://llongmane584.github.io/spoke-length-calculator/
 ## 機能
 
 - **スポーク長の精密計算**: 余弦定理(平面)とピタゴラスの定理(立体)を組み合わせたありふれた計算式を使用
-- **プリセット機能**: 作者所有のハブ/リムの組み合わせをプリセットとして選択可能
-  - Hope Pro 5 IS6 + Nextie Premium 2936（フロント/リア）
+- **プリセット機能**: 作者所有の部品から入力欄を埋められる。各見出しの横のチップで選択する
+  - ホイール単位: Hope Pro 5 CL / IS6 のハブ × Nextie Premium 2936 / Stan's Flow MK4（フロント/リア）
+  - ハブ単体・リム単体: それぞれ個別に選べるので、まだ組んだことのない組み合わせも試算できる
+  - チップは今の入力値を映す —— ホイールを選べばハブ・リムのチップも自動で点き、
+    値を手で書き換えると一致しなくなったチップが自動で消える
 - **豊富な入力パラメータ**:
   - ERD（有効リム径）
   - リムオフセット（左右の実効フランジ距離差を縮める方向へ自動適用）
@@ -71,7 +74,8 @@ pnpm lint
 ## 使い方
 
 1. **基本情報の入力**
-   - **プリセット選択**: ハブ/リムの組み合わせから選択（オプション）
+   - **プリセット**（オプション）: 「入力値」見出しの横のチップでホイールごと、
+     「リム」「ハブ」見出しの横のチップでその区画だけを埋められる
    - リムとハブの各種寸法を入力
    - スポーク本数と組み方を選択
 
@@ -99,6 +103,8 @@ pnpm lint
 │   ├── i18n.ts                    # 多言語化設定
 │   ├── rimOffset.ts               # リムオフセットのロジック
 │   ├── rimOffset.test.ts          # リムオフセットの単体テスト
+│   ├── partPresets.ts             # ハブ / リム部品プリセットの読み込みと一致判定
+│   ├── presetData.test.ts         # 全体プリセットと部品の数値がずれていないか検証
 │   ├── spokeCompare.ts            # ホイール比較のロジック
 │   ├── vite-env.d.ts              # Vite 環境型定義
 │   ├── assets/                    # 静的アセット
@@ -108,6 +114,7 @@ pnpm lint
 │   │   ├── ConfirmDialog.tsx      # 確認ダイアログ
 │   │   ├── HelpButton.tsx         # インラインヘルプの起動ボタン
 │   │   ├── HelpModal.tsx          # SVG 図解つきヘルプモーダル
+│   │   ├── PresetSelect.tsx       # プリセット選択 (CSS customizable select)
 │   │   ├── SegmentedControl.tsx   # セグメントコントロール
 │   │   └── Toast.tsx              # トースト通知コンポーネント
 │   ├── contexts/                  # React コンテキスト
@@ -121,13 +128,10 @@ pnpm lint
 │   ├── locales/                   # 翻訳ファイル
 │   │   ├── en.json                # 英語翻訳
 │   │   └── ja.json                # 日本語翻訳
-│   └── presets/                   # プリセットデータ (6 ファイル)
-│       ├── Hope-Pro-5-CL_Nextie-Premium-2936_Front.json
-│       ├── Hope-Pro-5-CL_Nextie-Premium-2936_Rear.json
-│       ├── Hope-Pro-5-IS6_Nextie-Premium-2936_Front.json
-│       ├── Hope-Pro-5-IS6_Nextie-Premium-2936_Rear.json
-│       ├── Hope-Pro-5-IS6_Stans-Flow-MK4_Front.json
-│       └── Hope-Pro-5-IS6_Stans-Flow-MK4_Rear.json
+│   └── presets/                   # プリセットデータ
+│       ├── *.json                 # ホイール単位: {ハブ}_{リム}_{Front|Rear}.json (6 ファイル)
+│       ├── hubs/                  # ハブ単体: {ハブ}_{Front|Rear}.json (4 ファイル)
+│       └── rims/                  # リム単体: {リム}.json (2 ファイル)
 ├── public/                        # 静的ファイル
 │   └── calculator.svg
 ├── dist/                          # ビルド出力

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -980,8 +980,10 @@ const FieldGroup: React.FC<{
   return (
     <div className={withRule ? 'border-t border-line pt-6' : undefined}>
       <div role="group" aria-labelledby={labelId}>
-        <div className="mb-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
-          <span id={labelId} className="flex items-center gap-2 text-sm font-semibold text-fg">
+        {/* 折り返さない。chip の中身が伸びても行数を変えないため (プリセットを
+            選ぶたびに見出しの位置が動くのを防ぐ)。 */}
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <span id={labelId} className="flex shrink-0 items-center gap-2 text-sm font-semibold text-fg">
             {icon}
             {label}
           </span>
@@ -1605,9 +1607,11 @@ const SpokeLengthCalculator: React.FC = () => {
           {/* Input section */}
           <div ref={inputSectionRef} className="space-y-6 p-5 sm:p-6">
             {/* プリセットは入力欄ではなく「ここを埋める材料の指定」なので、
-                フルワイドのフィールドを積まずに見出し行へ chip として添える。 */}
-            <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 border-b border-line pb-2">
-              <h2 className="text-xl font-semibold text-fg">{t('input.heading')}</h2>
+                フルワイドのフィールドを積まずに見出し行へ chip として添える。
+                折り返しは禁止 —— 選んだプリセット名の長短で行数が変わると、
+                選択のたびに見出しごと位置が跳ねる。 */}
+            <div className="flex items-center justify-between gap-3 border-b border-line pb-2">
+              <h2 className="shrink-0 text-xl font-semibold text-fg">{t('input.heading')}</h2>
               {presetOptions.length > 0 && (
                 <PresetSelect
                   id="preset"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useId, useLayoutEffect, useMemo, useRef } from 'react';
 import {
   ArrowLeftRight,
   ChevronDown,
@@ -7,7 +7,6 @@ import {
   FileUp,
   Moon,
   Save,
-  SlidersHorizontal,
   Sun,
   Tag,
   Trash2,
@@ -25,14 +24,38 @@ import { HelpModal, type HelpTopic } from './components/HelpModal';
 import { MtbHubIcon } from './components/icons/MtbHubIcon';
 import CompareWheels, { type WheelOption } from './components/CompareWheels';
 import { SegmentedControl, type SegmentedOption } from './components/SegmentedControl';
-import { btnPrimary, btnSecondary, btnGhost, nativeSelect, selectChevron } from './styles';
+import { PresetSelect, type PresetSelectGroup } from './components/PresetSelect';
+import {
+  btnPrimary,
+  btnSecondary,
+  btnGhost,
+  customizableSelect,
+  nativeSelect,
+  sectionHeading,
+  sectionHeadingIcon,
+  selectChevron,
+  supportsBaseSelect,
+} from './styles';
 import { assessRimOffset, getEffectiveFlangeDistances, type RimOffsetAssessment } from './rimOffset';
+import {
+  HUB_FIELDS,
+  RIM_FIELDS,
+  buildPartPresets,
+  matchPreset,
+  type MatchablePreset,
+  type PartPresetOption,
+} from './partPresets';
 
 // Dynamic import of preset data
+// `*` は `/` をまたがないので、この glob は下の hubs/ rims/ を拾わない。
 const presetModules = import.meta.glob('./presets/*.json', { eager: true });
+const hubPresetModules = import.meta.glob('./presets/hubs/*.json', { eager: true });
+const rimPresetModules = import.meta.glob('./presets/rims/*.json', { eager: true });
 
 // Type definitions
-interface Inputs {
+// interface ではなく type エイリアス。interface には暗黙のインデックスシグネチャが
+// 付かないので Record<string, string> を要求する matchPreset に渡せない。
+type Inputs = {
   erd: string;
   rimOffset: string;
   pitchCircleLeft: string;
@@ -43,7 +66,7 @@ interface Inputs {
   numberOfSpokes: string;
   crossingsLeft: string;
   crossingsRight: string;
-}
+};
 
 interface Results {
   left: number;
@@ -125,6 +148,21 @@ const inputFields = [
   'crossingsLeft',
   'crossingsRight',
 ] as const satisfies readonly InputField[];
+
+// 部品プリセットの担当欄。partPresets.ts 側は Inputs 型を知らない (Vite 非依存に
+// 保って node --test から読めるようにしてある) ので、ここで InputField[] として
+// 受け直す。フィールド名のタイポはこの代入でコンパイルエラーになる。
+const hubPresetFields: readonly InputField[] = HUB_FIELDS;
+const rimPresetFields: readonly InputField[] = RIM_FIELDS;
+const HUB_POSITIONS = ['front', 'rear'] as const;
+
+// ヘッダーの言語切替。プリセットとは性質が違う操作なので PresetSelect は使わないが、
+// base-select の分岐だけは同じ規則で揃える —— プリセットのポップアップだけが新しくて
+// 他が OS 標準のままだと、かえって古く見えるため。
+// 選択肢が素のテキストだけなので、畳んだ状態はブラウザ生成のボタンで足りる。
+const languageSelectClass = supportsBaseSelect
+  ? `${customizableSelect} preset-select min-h-9 w-auto py-1 pr-2 text-sm`
+  : `${nativeSelect} min-h-9 w-auto py-1 pr-8 text-sm`;
 
 // Tailwind の `sm:` 直下を指す。v4 のブレークポイントは rem (--breakpoint-sm: 40rem)
 // なので px で書くとルートフォントサイズを変えたときに CSS と JS がずれる —
@@ -544,9 +582,19 @@ const loadSavedCalculations = (): SavedCalculationsLoadResult => {
 };
 
 const PRESET_LOAD_RESULT = loadPresetOptions();
+// ハブ / リム単体のプリセット。全体プリセットと違い 10 項目すべては持たないので
+// getCalculationState では検証できず、専用のローダーを通す。
+const HUB_PRESET_LOAD_RESULT = buildPartPresets(hubPresetModules, HUB_FIELDS, true);
+const RIM_PRESET_LOAD_RESULT = buildPartPresets(rimPresetModules, RIM_FIELDS, false);
 const INITIAL_SAVED_CALCULATIONS = loadSavedCalculations();
 
-for (const error of PRESET_LOAD_RESULT.errors) {
+const PRESET_LOAD_ERRORS = [
+  ...PRESET_LOAD_RESULT.errors,
+  ...HUB_PRESET_LOAD_RESULT.errors,
+  ...RIM_PRESET_LOAD_RESULT.errors,
+];
+
+for (const error of PRESET_LOAD_ERRORS) {
   console.error(error);
 }
 
@@ -910,31 +958,40 @@ const RadialHint: React.FC = () => {
 };
 
 // Groups related input fields under a label, separated by a hairline rule.
-// The rule lives on the wrapper rather than on the fieldset itself: a bordered
-// fieldset gets a notch cut out of its top border where the legend sits.
-// `min-w-0` neutralises the fieldset UA default `min-inline-size: min-content`,
-// so a long unwrappable label can never push the form wider than its container.
+// The rule lives on the wrapper rather than on the group itself: a bordered
+// fieldset would get a notch cut out of its top border where the legend sits.
+//
+// fieldset/legend ではなく role="group" + aria-labelledby を使う。見出しの右へ
+// プリセットの chip を並べたいのだが、<legend> は fieldset のキャプションとして
+// 特別に描かれ、fieldset を grid/flex にしてもアイテムにならないので横に置けない。
+// かといって chip を <legend> の中に入れると、グループのアクセシブル名に
+// 選択中の部品名まで混ざってしまう。role="group" なら意味を保ったまま
+// レイアウトが自由になる (支援技術への伝わり方は fieldset/legend と等価)。
 const FieldGroup: React.FC<{
   label: string;
   icon: React.ReactNode;
+  /** 見出しの右に置く操作 (プリセットの chip)。 */
+  action?: React.ReactNode;
   withRule?: boolean;
   children: React.ReactNode;
-}> = ({ label, icon, withRule = true, children }) => (
-  <div className={withRule ? 'border-t border-line pt-6' : undefined}>
-    <fieldset className="min-w-0">
-      <legend className="mb-3 text-sm font-semibold text-fg">
-        <span className="flex items-center gap-2">
-          {icon}
-          {label}
-        </span>
-      </legend>
-      <div className="space-y-4">{children}</div>
-    </fieldset>
-  </div>
-);
+}> = ({ label, icon, action, withRule = true, children }) => {
+  const labelId = useId();
 
-const sectionHeading = 'mb-3 flex items-center gap-2 text-sm font-semibold text-fg';
-const sectionHeadingIcon = 'h-4 w-4 shrink-0 text-accent';
+  return (
+    <div className={withRule ? 'border-t border-line pt-6' : undefined}>
+      <div role="group" aria-labelledby={labelId}>
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
+          <span id={labelId} className="flex items-center gap-2 text-sm font-semibold text-fg">
+            {icon}
+            {label}
+          </span>
+          {action}
+        </div>
+        <div className="space-y-4">{children}</div>
+      </div>
+    </div>
+  );
+};
 
 // Regular number input component
 interface NumberInputProps {
@@ -1083,6 +1140,8 @@ const SpokeLengthCalculator: React.FC = () => {
   });
 
   const presetOptions = PRESET_LOAD_RESULT.options;
+  const hubPresetOptions = HUB_PRESET_LOAD_RESULT.options;
+  const rimPresetOptions = RIM_PRESET_LOAD_RESULT.options;
   const [savedCalculations, setSavedCalculations] = useState<SavedCalculation[]>(
     INITIAL_SAVED_CALCULATIONS.calculations,
   );
@@ -1092,7 +1151,6 @@ const SpokeLengthCalculator: React.FC = () => {
   const [calculationName, setCalculationName] = useState('');
   const [showJsonOutput, setShowJsonOutput] = useState(false);
   const [jsonData, setJsonData] = useState('');
-  const [selectedPreset, setSelectedPreset] = useState<string>('');
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [calculationToDelete, setCalculationToDelete] = useState<number | null>(null);
   const [helpTopic, setHelpTopic] = useState<HelpTopic | null>(null);
@@ -1175,6 +1233,64 @@ const SpokeLengthCalculator: React.FC = () => {
     return [...presetItems, ...savedItems];
   }, [presetOptions, savedCalculations]);
 
+  // プリセットの select は選択状態を state で覚えない。今の入力値に一致する定義を
+  // 毎回探して value にする —— これだけで「ホイールを選ぶとハブ / リムの欄も点く」
+  // 「フランジ距離を手で直すとハブの欄が消える」が同期処理なしに成り立つ。
+  const matchableWheelPresets = useMemo(
+    (): MatchablePreset[] => presetOptions.map(preset => ({ id: preset.id, fields: preset.data.inputs })),
+    [presetOptions],
+  );
+  const selectedPreset = matchPreset(matchableWheelPresets, inputs, inputFields);
+  const selectedHubPreset = matchPreset(hubPresetOptions, inputs, hubPresetFields);
+  const selectedRimPreset = matchPreset(rimPresetOptions, inputs, rimPresetFields);
+
+  const wheelPresetGroups = useMemo((): PresetSelectGroup[] => [{
+    items: presetOptions.map(preset => ({
+      id: preset.id,
+      name: preset.name,
+      spec: t('input.presetSpec.wheel', {
+        erd: preset.data.inputs.erd,
+        spokes: preset.data.inputs.numberOfSpokes,
+        crossLeft: preset.data.inputs.crossingsLeft,
+        crossRight: preset.data.inputs.crossingsRight,
+      }),
+    })),
+  }], [presetOptions, t]);
+
+  // ハブは前後で寸法が違うので optgroup で分ける。フロント組みにリアハブを
+  // 選んでしまう事故を、リストの並びの時点で防ぐ。
+  const hubPresetGroups = useMemo((): PresetSelectGroup[] => (
+    HUB_POSITIONS
+      .map(position => ({
+        label: t(`input.hubPosition.${position}`),
+        items: hubPresetOptions
+          .filter(option => option.position === position)
+          .map(option => ({
+            id: option.id,
+            name: option.name,
+            spec: t('input.presetSpec.hub', {
+              pcdLeft: option.fields.pitchCircleLeft,
+              pcdRight: option.fields.pitchCircleRight,
+              flangeLeft: option.fields.flangeDistanceLeft,
+              flangeRight: option.fields.flangeDistanceRight,
+              hole: option.fields.spokeHoleDiameter,
+            }),
+          })),
+      }))
+      .filter(group => group.items.length > 0)
+  ), [hubPresetOptions, t]);
+
+  const rimPresetGroups = useMemo((): PresetSelectGroup[] => [{
+    items: rimPresetOptions.map(option => ({
+      id: option.id,
+      name: option.name,
+      spec: t('input.presetSpec.rim', {
+        erd: option.fields.erd,
+        offset: option.fields.rimOffset,
+      }),
+    })),
+  }], [rimPresetOptions, t]);
+
   // タイトルは幅に関係なくフルで出す。375px でも折り返して収まり、
   // ヘッダーは flex-col になるので h1 が単独行を占める。
   const titleText = t('title');
@@ -1232,7 +1348,6 @@ const SpokeLengthCalculator: React.FC = () => {
   const handleInputChange = (field: keyof Inputs, value: string) => {
     setInputs(prev => ({ ...prev, [field]: value }));
     setTouchedFields(prev => ({ ...prev, [field]: true }));
-    setSelectedPreset('');
   };
 
   // Save calculation results
@@ -1274,22 +1389,31 @@ const SpokeLengthCalculator: React.FC = () => {
   const loadCalculation = (calculation: SavedCalculation) => {
     setInputs(calculation.inputs);
     setTouchedFields(createTouchedFields(true));
-    setSelectedPreset('');
   };
 
   // Load preset
   const loadPreset = (presetId: string) => {
-    if (presetId === '') {
-      setSelectedPreset('');
-      return;
-    }
-    
     const preset = presetOptions.find(p => p.id === presetId);
     if (preset) {
       setInputs(preset.data.inputs);
       setTouchedFields({});
-      setSelectedPreset(presetId);
     }
+  };
+
+  // Load a hub / rim part preset.
+  // 部品は自分の担当欄だけを塗る。全体プリセットのように inputs を丸ごと差し替えると、
+  // 組み方の設定やもう一方の部品の値まで巻き添えで消えてしまう。
+  //
+  // touchedFields には触れない —— 塗った欄は必ず非空になり、visibleFieldErrors は
+  // 「touched または非空」で出すので、値がおかしければそのままエラーが見える。
+  const loadPartPreset = (options: PartPresetOption[], partId: string) => {
+    const part = options.find(option => option.id === partId);
+
+    if (part === undefined) {
+      return;
+    }
+
+    setInputs(prev => ({ ...prev, ...part.fields }));
   };
 
   // Delete saved calculation
@@ -1400,7 +1524,6 @@ const SpokeLengthCalculator: React.FC = () => {
           if (normalizedInputs !== null) {
             setInputs(normalizedInputs);
             setTouchedFields(createTouchedFields(true));
-            setSelectedPreset('');
 
             const importedCalculation = getCalculationState(normalizedInputs);
             showToast(
@@ -1447,12 +1570,14 @@ const SpokeLengthCalculator: React.FC = () => {
                 value={i18n.language}
                 onChange={(e) => handleLanguageChange(e.target.value)}
                 aria-label={t('language.label')}
-                className={`${nativeSelect} min-h-9 w-auto py-1 pr-8 text-sm`}
+                className={languageSelectClass}
               >
                 <option value="en">English</option>
                 <option value="ja">日本語</option>
               </select>
-              <ChevronDown aria-hidden="true" className={`${selectChevron} right-2.5`} />
+              {!supportsBaseSelect && (
+                <ChevronDown aria-hidden="true" className={`${selectChevron} right-2.5`} />
+              )}
             </div>
             <button
               onClick={toggleTheme}
@@ -1479,47 +1604,44 @@ const SpokeLengthCalculator: React.FC = () => {
         <div ref={sheetRef} className="group rounded-xl border border-line bg-surface">
           {/* Input section */}
           <div ref={inputSectionRef} className="space-y-6 p-5 sm:p-6">
-            <h2 className="text-xl font-semibold text-fg border-b border-line pb-2">{t('input.heading')}</h2>
+            {/* プリセットは入力欄ではなく「ここを埋める材料の指定」なので、
+                フルワイドのフィールドを積まずに見出し行へ chip として添える。 */}
+            <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 border-b border-line pb-2">
+              <h2 className="text-xl font-semibold text-fg">{t('input.heading')}</h2>
+              {presetOptions.length > 0 && (
+                <PresetSelect
+                  id="preset"
+                  label={t('input.preset')}
+                  placeholder={t('input.presetPlaceholder')}
+                  value={selectedPreset}
+                  groups={wheelPresetGroups}
+                  onSelect={loadPreset}
+                />
+              )}
+            </div>
 
           <div className="space-y-6">
-            {PRESET_LOAD_RESULT.errors.length > 0 && (
+            {PRESET_LOAD_ERRORS.length > 0 && (
               <InitialDataAlert
                 message={t('alerts.presetLoadError')}
                 severity="error"
               />
             )}
 
-            {/* Preset selection - only show if presets exist */}
-            {presetOptions.length > 0 && (
-              <div>
-                <label htmlFor="preset" className={sectionHeading}>
-                  <SlidersHorizontal aria-hidden="true" className={sectionHeadingIcon} />
-                  {t('input.preset')}
-                </label>
-                <div className="relative">
-                  <select
-                    id="preset"
-                    value={selectedPreset}
-                    onChange={(e) => loadPreset(e.target.value)}
-                    className={nativeSelect}
-                  >
-                    <option value="">{t('input.presetOption')}</option>
-                    {presetOptions.map((preset) => (
-                      <option key={preset.id} value={preset.id}>
-                        {preset.name}
-                      </option>
-                    ))}
-                  </select>
-                  <ChevronDown aria-hidden="true" className={selectChevron} />
-                </div>
-              </div>
-            )}
-
-            {/* Without the preset block above, this rule would double up with the h2 border */}
             <FieldGroup
               label={t('input.group.rim')}
               icon={<Circle aria-hidden="true" className={sectionHeadingIcon} />}
-              withRule={presetOptions.length > 0}
+              withRule={false}
+              action={rimPresetOptions.length > 0 && (
+                <PresetSelect
+                  id="rimPreset"
+                  label={t('input.rimPreset')}
+                  placeholder={t('input.rimPresetPlaceholder')}
+                  value={selectedRimPreset}
+                  groups={rimPresetGroups}
+                  onSelect={partId => loadPartPreset(rimPresetOptions, partId)}
+                />
+              )}
             >
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
@@ -1569,6 +1691,16 @@ const SpokeLengthCalculator: React.FC = () => {
             <FieldGroup
               label={t('input.group.hub')}
               icon={<MtbHubIcon aria-hidden="true" className={sectionHeadingIcon} />}
+              action={hubPresetOptions.length > 0 && (
+                <PresetSelect
+                  id="hubPreset"
+                  label={t('input.hubPreset')}
+                  placeholder={t('input.hubPresetPlaceholder')}
+                  value={selectedHubPreset}
+                  groups={hubPresetGroups}
+                  onSelect={partId => loadPartPreset(hubPresetOptions, partId)}
+                />
+              )}
             >
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import {
   btnSecondary,
   btnGhost,
   customizableSelect,
+  dismissOpenPicker,
   nativeSelect,
   sectionHeading,
   sectionHeadingIcon,
@@ -1571,6 +1572,7 @@ const SpokeLengthCalculator: React.FC = () => {
               <select
                 value={i18n.language}
                 onChange={(e) => handleLanguageChange(e.target.value)}
+                onPointerDown={supportsBaseSelect ? dismissOpenPicker : undefined}
                 aria-label={t('language.label')}
                 className={languageSelectClass}
               >

--- a/src/components/CompareWheels.tsx
+++ b/src/components/CompareWheels.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronDown, CircleCheck, TriangleAlert } from 'lucide-react';
+import { CircleCheck, TriangleAlert } from 'lucide-react';
 import { compareWheels, type WheelSpec } from '../spokeCompare';
-import { nativeSelect, selectChevron } from '../styles';
+import { PresetSelect, type PresetSelectGroup } from './PresetSelect';
 
 export interface WheelOption {
   id: string;
@@ -33,49 +33,35 @@ const CompareWheels: React.FC<Props> = ({ options, selectedA, selectedB, onChang
     return compareWheels(specA, specB);
   }, [specA, specB]);
 
+  // optgroup が要るのでネイティブ select のまま。見た目は PresetSelect が
+  // 入力欄側のプリセット選択と揃える (対応ブラウザでは appearance: base-select)。
+  const groups = useMemo((): PresetSelectGroup[] => [
+    { label: t('compare.groupPresets'), items: presets.map(o => ({ id: o.id, name: o.label })) },
+    { label: t('compare.groupSaved'), items: saved.map(o => ({ id: o.id, name: o.label })) },
+  ].filter(group => group.items.length > 0), [presets, saved, t]);
+
   const renderSelect = (
+    id: string,
     value: string,
     onChange: (id: string) => void,
     label: string,
   ) => (
-    <div className="flex flex-col gap-1.5">
-      <label className="text-sm font-medium text-fg-muted">
-        {label}
-      </label>
-      {/* optgroup が必要なのでネイティブ select のまま。ポップアップの見た目は
-          index.css の base 層にある color-scheme がテーマに追従させる。 */}
-      <div className="relative">
-        <select
-          value={value}
-          onChange={e => onChange(e.target.value)}
-          className={nativeSelect}
-        >
-          <option value="">{t('compare.placeholder')}</option>
-          {presets.length > 0 && (
-            <optgroup label={t('compare.groupPresets')}>
-              {presets.map(o => (
-                <option key={o.id} value={o.id}>{o.label}</option>
-              ))}
-            </optgroup>
-          )}
-          {saved.length > 0 && (
-            <optgroup label={t('compare.groupSaved')}>
-              {saved.map(o => (
-                <option key={o.id} value={o.id}>{o.label}</option>
-              ))}
-            </optgroup>
-          )}
-        </select>
-        <ChevronDown aria-hidden="true" className={selectChevron} />
-      </div>
-    </div>
+    <PresetSelect
+      id={id}
+      variant="field"
+      label={label}
+      placeholder={t('compare.placeholder')}
+      value={value}
+      groups={groups}
+      onSelect={onChange}
+    />
   );
 
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        {renderSelect(selectedA, onChangeA, t('compare.wheelA'))}
-        {renderSelect(selectedB, onChangeB, t('compare.wheelB'))}
+        {renderSelect('compareWheelA', selectedA, onChangeA, t('compare.wheelA'))}
+        {renderSelect('compareWheelB', selectedB, onChangeB, t('compare.wheelB'))}
       </div>
 
       {result === null ? (

--- a/src/components/PresetSelect.tsx
+++ b/src/components/PresetSelect.tsx
@@ -1,0 +1,133 @@
+import { ChevronDown } from 'lucide-react';
+import { Fragment, createElement } from 'react';
+
+import {
+  customizableSelect,
+  customizableSelectChip,
+  fieldLabel,
+  nativeSelect,
+  nativeSelectChip,
+  selectChevron,
+  supportsBaseSelect,
+} from '../styles';
+
+/**
+ * 畳んだ状態を自分で組むための <button><selectedcontent>。
+ *
+ * 省略するとブラウザが同等のボタンを起こすが、それは author 側の CSS から掴めず、
+ * 長いプリセット名がチップからはみ出しても省略記号にできない。自前で置けば
+ * min-width:0 と text-overflow を効かせられる。
+ *
+ * <selectedcontent> は @types/react にまだ無い要素。JSX で書くには
+ * JSX.IntrinsicElements の拡張が要り、それには namespace が必要で eslint の
+ * no-namespace に触れるので createElement で作る。
+ *
+ * なお React の DOM ネスト検証は <select> の子に <button> を許さず、開発ビルドで
+ * 警告を 1 本出す (customizable select がまだ React 側に反映されていないため)。
+ * 本番ビルドでは出ず、SSR もしていないので実害はない。
+ */
+const SelectedContent = () => createElement('selectedcontent');
+
+export interface PresetSelectItem {
+  id: string;
+  name: string;
+  /** 展開時に名前の下へ添える寸法の要約 */
+  spec?: string;
+}
+
+export interface PresetSelectGroup {
+  /** 省略すると optgroup を挟まずそのまま並べる */
+  label?: string;
+  items: PresetSelectItem[];
+}
+
+interface PresetSelectProps {
+  id: string;
+  /**
+   * chip バリアントでは見出しを出さずアクセシブル名として使う。
+   * 畳んだ chip には選択中の値そのものが出るので、見出しを重ねると冗長になる。
+   */
+  label: string;
+  placeholder: string;
+  /** chip = 見出し行に添える丸いピル / field = ラベル付きのフルワイド入力欄 */
+  variant?: 'chip' | 'field';
+  /** '' なら未選択。state ではなく、今の入力値に一致する定義の id を渡すこと。 */
+  value: string;
+  groups: PresetSelectGroup[];
+  onSelect: (id: string) => void;
+}
+
+// 寸法の要約は子要素ではなく data 属性で渡し、CSS の ::after + attr() で描く。
+// <option> の中に <span> を置くと React の DOM ネスト検証に引っかかるうえ、
+// base-select 非対応のブラウザではテキストが連結されて 1 行に潰れる。
+// ::after なら畳んだ状態にも複製されないので、閉じたときは自動的に名前だけになる。
+const renderItems = (items: PresetSelectItem[]) => (
+  items.map(item => (
+    <option key={item.id} value={item.id} data-spec={item.spec}>
+      {item.name}
+    </option>
+  ))
+);
+
+export function PresetSelect({
+  id,
+  label,
+  placeholder,
+  variant = 'chip',
+  value,
+  groups,
+  onSelect,
+}: PresetSelectProps) {
+  const isChip = variant === 'chip';
+  // preset-select クラスも分岐に含める。index.css の @supports ブロックは
+  // レイヤ外なので Tailwind の appearance-none より強い —— 無条件に付けると
+  // フォールバックのつもりの select にまで base-select が当たってしまう。
+  const selectClass = supportsBaseSelect
+    ? `${isChip ? customizableSelectChip : customizableSelect} preset-select`
+    : (isChip ? nativeSelectChip : nativeSelect);
+
+  const select = (
+    <div className={isChip ? 'relative inline-flex max-w-full' : 'relative'}>
+      <select
+        id={id}
+        value={value}
+        onChange={event => onSelect(event.target.value)}
+        aria-label={isChip ? label : undefined}
+        className={selectClass}
+      >
+        {supportsBaseSelect && (
+          <button>
+            <SelectedContent />
+          </button>
+        )}
+        {/* プレースホルダを disabled にしてはいけない。'' は初期状態でも手編集後でも
+            起きる常態で、disabled な option は選択対象にならないため、ブラウザが
+            代わりに先頭の項目を選んでしまう (入力欄が空なのに部品名が出る)。 */}
+        <option value="">{placeholder}</option>
+        {groups.map((group, index) => (
+          group.label === undefined ? (
+            <Fragment key={`group-${index}`}>{renderItems(group.items)}</Fragment>
+          ) : (
+            <optgroup key={group.label} label={group.label}>
+              {renderItems(group.items)}
+            </optgroup>
+          )
+        ))}
+      </select>
+      {!supportsBaseSelect && (
+        <ChevronDown aria-hidden="true" className={isChip ? `${selectChevron} right-2.5` : selectChevron} />
+      )}
+    </div>
+  );
+
+  if (isChip) {
+    return select;
+  }
+
+  return (
+    <div>
+      <label htmlFor={id} className={fieldLabel}>{label}</label>
+      {select}
+    </div>
+  );
+}

--- a/src/components/PresetSelect.tsx
+++ b/src/components/PresetSelect.tsx
@@ -87,7 +87,9 @@ export function PresetSelect({
     : (isChip ? nativeSelectChip : nativeSelect);
 
   const select = (
-    <div className={isChip ? 'relative inline-flex max-w-full' : 'relative'}>
+    // chip の枠は行の余りを埋めるだけ (flex-1 + 上限)。中身の長さに幅を決めさせない
+    // ので、何を選んでもチップの位置と大きさは初期状態のまま動かない。
+    <div className={isChip ? 'relative flex-1 min-w-0 max-w-64' : 'relative'}>
       <select
         id={id}
         value={value}

--- a/src/components/PresetSelect.tsx
+++ b/src/components/PresetSelect.tsx
@@ -4,6 +4,7 @@ import { Fragment, createElement } from 'react';
 import {
   customizableSelect,
   customizableSelectChip,
+  dismissOpenPicker,
   fieldLabel,
   nativeSelect,
   nativeSelectChip,
@@ -94,6 +95,7 @@ export function PresetSelect({
         id={id}
         value={value}
         onChange={event => onSelect(event.target.value)}
+        onPointerDown={supportsBaseSelect ? dismissOpenPicker : undefined}
         aria-label={isChip ? label : undefined}
         className={selectClass}
       >

--- a/src/index.css
+++ b/src/index.css
@@ -222,3 +222,146 @@
     color-scheme: dark;
   }
 }
+
+/* CSS customizable select。ネイティブ <select> の意味論・キーボード操作・
+   スクリーンリーダ・モバイルの UI をそのまま保ったまま、ポップアップの中身だけを
+   自前で描く。独自コンボボックスを書かずに済むので ARIA を手で組む必要がない
+   (SegmentedControl.tsx 冒頭の方針と同じ理由)。
+
+   対応していないブラウザはこのブロックに入らない。PresetSelect が
+   CSS.supports() を見てクラス文字列とマークアップの両方を従来のものへ切り替えるので、
+   ここが丸ごと無視されても壊れない。appearance-none を持つ nativeSelect と
+   このブロックが同じ要素に同時に当たることは無い。
+
+   色は必ずトークン変数を読む。.dark が変数側を差し替えるので、これだけで
+   ライト / ダーク両対応になる (dark: もパレット直参照も要らない)。
+
+   @layer に入れない —— 素のセレクタを Tailwind のユーティリティ層より後に置いて、
+   カスケード順の綱引きを避ける。 */
+@supports (appearance: base-select) {
+
+  .preset-select,
+  .preset-select::picker(select) {
+    appearance: base-select;
+  }
+
+  /* 閉じた状態。<button><selectedcontent> を自前で置いてあるので、
+     長いプリセット名は省略記号に落として矢印を必ず残す。 */
+  .preset-select {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    text-align: start;
+    font: inherit;
+  }
+
+  .preset-select>button {
+    flex: 1 1 auto;
+    min-width: 0;
+    appearance: none;
+    border: 0;
+    padding: 0;
+    background: none;
+    font: inherit;
+    color: inherit;
+    text-align: start;
+  }
+
+  .preset-select selectedcontent {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .preset-select::picker-icon {
+    flex: none;
+    color: var(--color-fg-subtle);
+    transition: rotate 150ms ease;
+  }
+
+  .preset-select:open::picker-icon {
+    rotate: 180deg;
+  }
+
+  .preset-select::picker(select) {
+    border: 1px solid var(--color-line-strong);
+    border-radius: 0.75rem;
+    background: var(--color-surface);
+    box-shadow: 0 12px 32px -12px rgb(0 0 0 / 0.35);
+    padding: 0.25rem;
+    max-height: 20rem;
+    overflow-y: auto;
+    /* トップレイヤの要素なので、display と overlay も allow-discrete で繋がないと
+       閉じるアニメーションが再生されずに消える。 */
+    opacity: 0;
+    translate: 0 -0.25rem;
+    transition:
+      opacity 120ms ease,
+      translate 120ms ease,
+      display 120ms allow-discrete,
+      overlay 120ms allow-discrete;
+  }
+
+  .preset-select:open::picker(select) {
+    opacity: 1;
+    translate: 0;
+  }
+
+  /* 開くときの初期値。:open の規則より後に置く必要がある。 */
+  @starting-style {
+    .preset-select:open::picker(select) {
+      opacity: 0;
+      translate: 0 -0.25rem;
+    }
+  }
+
+  .preset-select optgroup {
+    padding: 0.5rem 0.5rem 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--color-fg-subtle);
+  }
+
+  /* ✓ は絶対配置にして本文のフローから外す。グリッドで列に分けると、素のテキストだけの
+     option (言語切替やホイール比較) が無名アイテムになって ✓ の列へ落ちてしまう。
+     左の padding が ✓ のぶんの座席。 */
+  .preset-select option {
+    position: relative;
+    display: block;
+    padding: 0.5rem 0.5rem 0.5rem 1.75rem;
+    border-radius: 0.5rem;
+    color: var(--color-fg);
+  }
+
+  .preset-select option:hover,
+  .preset-select option:focus {
+    background: var(--color-sunken);
+  }
+
+  .preset-select option::checkmark {
+    position: absolute;
+    left: 0.5rem;
+    top: 0.5rem;
+    color: var(--color-accent);
+  }
+
+  /* 寸法の要約。子要素ではなく data 属性から起こす —— <option> の中に要素を置くと
+     React の DOM ネスト検証に引っかかる。擬似要素は畳んだ状態には複製されないので、
+     閉じたセレクトは何もしなくても名前だけの 1 行に収まる。 */
+  .preset-select option[data-spec]::after {
+    content: attr(data-spec);
+    display: block;
+    margin-top: 0.125rem;
+    font-size: 0.75rem;
+    color: var(--color-fg-subtle);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+
+    .preset-select::picker(select),
+    .preset-select::picker-icon {
+      transition: none;
+    }
+  }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2,9 +2,21 @@
   "title": "Spoke Length Calculator",
   "input": {
     "heading": "Input Values",
-    "preset": "Preset",
-    "presetPlaceholder": "Select a preset",
-    "presetOption": "Please Select",
+    "preset": "Wheel preset",
+    "presetPlaceholder": "Pick a wheel",
+    "hubPreset": "Hub preset",
+    "hubPresetPlaceholder": "Pick a hub",
+    "rimPreset": "Rim preset",
+    "rimPresetPlaceholder": "Pick a rim",
+    "hubPosition": {
+      "front": "Front",
+      "rear": "Rear"
+    },
+    "presetSpec": {
+      "wheel": "ERD {{erd}} · {{spokes}}H · {{crossLeft}}x/{{crossRight}}x",
+      "hub": "PCD {{pcdLeft}}/{{pcdRight}} · Flange {{flangeLeft}}/{{flangeRight}} · Hole {{hole}}",
+      "rim": "ERD {{erd}} · Offset {{offset}}"
+    },
     "erd": "ERD (mm)",
     "erdPlaceholder": "Effective Rim Diameter",
     "rimOffset": "Rim Offset (mm)",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -2,9 +2,21 @@
   "title": "スポーク長計算機",
   "input": {
     "heading": "入力値",
-    "preset": "プリセット",
-    "presetPlaceholder": "プリセットを選択",
-    "presetOption": "選択してください",
+    "preset": "ホイールプリセット",
+    "presetPlaceholder": "ホイールを選ぶ",
+    "hubPreset": "ハブプリセット",
+    "hubPresetPlaceholder": "ハブを選ぶ",
+    "rimPreset": "リムプリセット",
+    "rimPresetPlaceholder": "リムを選ぶ",
+    "hubPosition": {
+      "front": "フロント",
+      "rear": "リア"
+    },
+    "presetSpec": {
+      "wheel": "ERD {{erd}} · {{spokes}}H · {{crossLeft}}/{{crossRight}}クロス",
+      "hub": "PCD {{pcdLeft}}/{{pcdRight}} · フランジ {{flangeLeft}}/{{flangeRight}} · 穴 {{hole}}",
+      "rim": "ERD {{erd}} · オフセット {{offset}}"
+    },
     "erd": "ERD (mm)",
     "erdPlaceholder": "有効リム直径",
     "rimOffset": "リムオフセット (mm)",

--- a/src/partPresets.ts
+++ b/src/partPresets.ts
@@ -1,0 +1,178 @@
+// ハブ / リム単体の「部品プリセット」を読むための純粋モジュール。
+//
+// import.meta.glob は Vite 専用なので呼び出し側 (App.tsx) に置き、ここはモジュールの
+// マップを受け取るだけにしてある —— おかげで node --test から素で読める。
+//
+// 全体プリセット (src/presets/*.json) が 10 項目すべてを持つのに対し、部品プリセットは
+// 自分の担当項目だけを持つ。担当の切り方は入力フォームの FieldGroup と同じ:
+// リム = ERD / リムオフセット、ハブ = PCD / フランジ距離 / スポーク穴径。
+// スポーク本数とクロス数は「ハブとリムの穴数が一致して初めて決まる」組み方側の値なので
+// 部品には含めない (同じハブが 28H/32H で存在しうる)。
+
+export const HUB_FIELDS = [
+  'pitchCircleLeft',
+  'pitchCircleRight',
+  'flangeDistanceLeft',
+  'flangeDistanceRight',
+  'spokeHoleDiameter',
+] as const;
+
+export const RIM_FIELDS = ['erd', 'rimOffset'] as const;
+
+export type HubPosition = 'front' | 'rear';
+
+export interface PartPresetOption {
+  /** ファイル名から拡張子を除いたもの。select の option value になる */
+  id: string;
+  name: string;
+  /** ハブのみ。select の optgroup 見出しに使う */
+  position?: HubPosition;
+  fields: Record<string, string>;
+}
+
+export interface PartPresetLoadResult {
+  options: PartPresetOption[];
+  errors: string[];
+}
+
+/** matchPreset に渡せる最小形。全体プリセットもこの形に均してから渡す */
+export interface MatchablePreset {
+  id: string;
+  fields: Record<string, string>;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => (
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+);
+
+const isHubPosition = (value: unknown): value is HubPosition => (
+  value === 'front' || value === 'rear'
+);
+
+// 部品の値は必ず有限の数値でなければならない。全体プリセットのローダーは文字列を
+// そのまま通して後段の計算で弾いているが、部品は単体では計算できないのでここで弾く。
+const normalizeFieldValue = (value: unknown): string | null => {
+  let text: string;
+
+  if (typeof value === 'string') {
+    text = value.trim();
+  } else if (typeof value === 'number' && Number.isFinite(value)) {
+    text = String(value);
+  } else {
+    return null;
+  }
+
+  if (text === '' || !Number.isFinite(Number(text))) {
+    return null;
+  }
+
+  return text;
+};
+
+// displayName が無いファイル用の代替表示名。全体プリセットのローダーと同じ変換。
+const deriveName = (id: string): string => (
+  id.replace(/[-_]/g, ' ').replace(/\b\w/g, char => char.toUpperCase())
+);
+
+/**
+ * glob で集めたモジュール群を検証して select 用の選択肢に変換する。
+ * 検証に落ちたファイルは黙って捨てず errors に理由を積む —— 呼び出し側が
+ * 既存のプリセット読み込みエラーと同じバナーに合流させる。
+ */
+export const buildPartPresets = (
+  modules: Record<string, unknown>,
+  fields: readonly string[],
+  requirePosition: boolean,
+): PartPresetLoadResult => {
+  const options: PartPresetOption[] = [];
+  const errors: string[] = [];
+
+  for (const [path, module] of Object.entries(modules)) {
+    if (!isRecord(module)) {
+      errors.push(`Invalid part preset in ${path}: not an object`);
+      continue;
+    }
+
+    const rawInputs = module.inputs;
+
+    if (!isRecord(rawInputs)) {
+      errors.push(`Invalid part preset in ${path}: missing or invalid "inputs"`);
+      continue;
+    }
+
+    const normalizedFields: Record<string, string> = {};
+    let invalidField: string | null = null;
+
+    for (const field of fields) {
+      const normalizedValue = normalizeFieldValue(rawInputs[field]);
+
+      if (normalizedValue === null) {
+        invalidField = field;
+        break;
+      }
+
+      normalizedFields[field] = normalizedValue;
+    }
+
+    if (invalidField !== null) {
+      errors.push(`Invalid part preset in ${path}: "${invalidField}" is missing or not a number`);
+      continue;
+    }
+
+    const { position } = module;
+
+    if (requirePosition && !isHubPosition(position)) {
+      errors.push(`Invalid part preset in ${path}: "position" must be "front" or "rear"`);
+      continue;
+    }
+
+    const id = path.split('/').pop()?.replace(/\.json$/, '') ?? path;
+    const displayName = module.displayName;
+
+    options.push({
+      id,
+      name: typeof displayName === 'string' && displayName !== '' ? displayName : deriveName(id),
+      ...(isHubPosition(position) ? { position } : {}),
+      fields: normalizedFields,
+    });
+  }
+
+  return { options, errors };
+};
+
+// 数値として比べる —— "3.0" と "3"、"35.60" と "35.6" は同じ部品を指す。
+// ただし片方でも空なら不一致。Number('') が 0 になるので、未入力の欄が
+// たまたま 0 の定義と一致してしまう事故を塞ぐ。
+const valuesEqual = (a: string | undefined, b: string | undefined): boolean => {
+  if (a === undefined || b === undefined) {
+    return false;
+  }
+
+  const left = a.trim();
+  const right = b.trim();
+
+  if (left === '' || right === '') {
+    return false;
+  }
+
+  return Number(left) === Number(right);
+};
+
+/**
+ * 今の入力値に一致する定義の id を返す。無ければ ''。
+ *
+ * プリセットの select はこの戻り値をそのまま value にする。選択状態を state で
+ * 覚えないので、「ホイールプリセットを選ぶとハブ / リムの欄も点く」「フランジ距離を
+ * 手で書き換えるとハブの欄が消える」が同期処理なしで成立する。
+ */
+export const matchPreset = (
+  options: readonly MatchablePreset[],
+  inputs: Readonly<Record<string, string>>,
+  fields: readonly string[],
+): string => {
+  const matched = options.find(
+    option => fields.every(field => valuesEqual(option.fields[field], inputs[field])),
+  );
+
+  return matched?.id ?? '';
+};

--- a/src/presetData.test.ts
+++ b/src/presetData.test.ts
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+import { readFile, readdir } from 'node:fs/promises';
+import test from 'node:test';
+
+import { HUB_FIELDS, RIM_FIELDS, buildPartPresets } from './partPresets.ts';
+
+// 全体プリセット (ハブ+リムの組み合わせ) と部品プリセットは同じ数値を重複して持つ。
+// 参照方式に作り替えて重複そのものを無くす手もあったが、動いている 6 ファイルの
+// スキーマ移行に見合わないと判断した。代わりに、ずれたら落ちるテストをここに置く。
+//
+// 対応付けはファイル名の規約でとる:
+//   presets/{ハブ}_{リム}_{Front|Rear}.json
+//     -> presets/hubs/{ハブ}_{Front|Rear}.json + presets/rims/{リム}.json
+
+const presetsUrl = new URL('./presets/', import.meta.url);
+const hubsUrl = new URL('./presets/hubs/', import.meta.url);
+const rimsUrl = new URL('./presets/rims/', import.meta.url);
+
+const readJsonDir = async (dirUrl: URL): Promise<Record<string, unknown>> => {
+  const entries = await readdir(dirUrl, { withFileTypes: true });
+  const fileNames = entries
+    .filter(entry => entry.isFile() && entry.name.endsWith('.json'))
+    .map(entry => entry.name)
+    .sort();
+
+  const modules: Record<string, unknown> = {};
+
+  for (const fileName of fileNames) {
+    modules[fileName] = JSON.parse(await readFile(new URL(fileName, dirUrl), 'utf8')) as unknown;
+  }
+
+  return modules;
+};
+
+const readInputs = (fileName: string, module: unknown): Record<string, string> => {
+  assert.ok(
+    typeof module === 'object' && module !== null && 'inputs' in module,
+    `${fileName}: "inputs" が無い`,
+  );
+
+  const { inputs } = module as { inputs: unknown };
+
+  assert.ok(
+    typeof inputs === 'object' && inputs !== null,
+    `${fileName}: "inputs" がオブジェクトでない`,
+  );
+
+  return inputs as Record<string, string>;
+};
+
+const loadParts = async () => {
+  const hubs = buildPartPresets(await readJsonDir(hubsUrl), HUB_FIELDS, true);
+  const rims = buildPartPresets(await readJsonDir(rimsUrl), RIM_FIELDS, false);
+
+  return { hubs, rims };
+};
+
+test('part presets all pass validation', async () => {
+  const { hubs, rims } = await loadParts();
+
+  assert.deepEqual(hubs.errors, []);
+  assert.deepEqual(rims.errors, []);
+  assert.ok(hubs.options.length > 0, 'ハブ部品が 1 件も読めていない');
+  assert.ok(rims.options.length > 0, 'リム部品が 1 件も読めていない');
+});
+
+test('every wheel preset agrees with the hub and rim parts it is named after', async () => {
+  const wheels = await readJsonDir(presetsUrl);
+  const { hubs, rims } = await loadParts();
+
+  assert.ok(Object.keys(wheels).length > 0, '全体プリセットが 1 件も読めていない');
+
+  for (const [fileName, module] of Object.entries(wheels)) {
+    const id = fileName.replace(/\.json$/, '');
+    const tokens = id.split('_');
+
+    assert.equal(
+      tokens.length,
+      3,
+      `${fileName}: ファイル名は {ハブ}_{リム}_{Front|Rear} の 3 トークンでなければならない`,
+    );
+
+    const [hubToken, rimToken, position] = tokens;
+    const hubId = `${hubToken}_${position}`;
+    const hub = hubs.options.find(option => option.id === hubId);
+    const rim = rims.options.find(option => option.id === rimToken);
+
+    assert.ok(hub, `${fileName}: 対応する部品 hubs/${hubId}.json が無い`);
+    assert.ok(rim, `${fileName}: 対応する部品 rims/${rimToken}.json が無い`);
+
+    const inputs = readInputs(fileName, module);
+
+    for (const field of HUB_FIELDS) {
+      assert.equal(
+        Number(inputs[field]),
+        Number(hub.fields[field]),
+        `${fileName}: ${field} が hubs/${hubId}.json と食い違う`,
+      );
+    }
+
+    for (const field of RIM_FIELDS) {
+      assert.equal(
+        Number(inputs[field]),
+        Number(rim.fields[field]),
+        `${fileName}: ${field} が rims/${rimToken}.json と食い違う`,
+      );
+    }
+  }
+});
+
+// プリセットの select は「今の入力値に一致する定義」を表示する。同じ数値の定義が
+// 2 つあると先に見つかった方だけが表示され、もう一方は永久に選べないように見える。
+test('no two presets share the same numbers', async () => {
+  const wheels = await readJsonDir(presetsUrl);
+  const { hubs, rims } = await loadParts();
+
+  const assertUnique = (label: string, entries: { id: string; key: string }[]) => {
+    const seen = new Map<string, string>();
+
+    for (const entry of entries) {
+      const previous = seen.get(entry.key);
+      assert.equal(previous, undefined, `${label}: ${previous} と ${entry.id} の数値が完全に同じ`);
+      seen.set(entry.key, entry.id);
+    }
+  };
+
+  const toKey = (fields: Record<string, string>, names: readonly string[]): string => (
+    names.map(name => String(Number(fields[name]))).join('/')
+  );
+
+  assertUnique('全体プリセット', Object.entries(wheels).map(([fileName, module]) => ({
+    id: fileName,
+    key: toKey(readInputs(fileName, module), [...HUB_FIELDS, ...RIM_FIELDS]),
+  })));
+
+  // ハブは position を鍵に含めない —— 一致判定は入力欄の値だけを見るので、
+  // 前後が違っても数値が同じなら select 上では見分けがつかない。
+  assertUnique('ハブ部品', hubs.options.map(option => ({
+    id: option.id,
+    key: toKey(option.fields, HUB_FIELDS),
+  })));
+
+  assertUnique('リム部品', rims.options.map(option => ({
+    id: option.id,
+    key: toKey(option.fields, RIM_FIELDS),
+  })));
+});
+
+// 部品を presets/ 直下に置くと、全体プリセット用の import.meta.glob('./presets/*.json')
+// が拾ってしまい、計算できないプリセットとしてエラーバナーが出っぱなしになる。
+// 件数は固定しない —— 全体プリセットが増えてもこのテストは通ってほしい。
+test('src/presets holds only whole-wheel presets at its top level', async () => {
+  const entries = await readdir(presetsUrl, { withFileTypes: true });
+  const wheels = await readJsonDir(presetsUrl);
+
+  const directories = entries
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name)
+    .sort();
+
+  assert.deepEqual(directories, ['hubs', 'rims']);
+  assert.ok(Object.keys(wheels).length > 0, '全体プリセットが 1 件も読めていない');
+
+  for (const [fileName, module] of Object.entries(wheels)) {
+    const inputs = readInputs(fileName, module);
+
+    for (const field of [...HUB_FIELDS, ...RIM_FIELDS]) {
+      assert.ok(
+        inputs[field] !== undefined,
+        `${fileName}: ${field} が無い。部品プリセットは presets/hubs か presets/rims に置く`,
+      );
+    }
+  }
+});

--- a/src/presets/hubs/Hope-Pro-5-CL_Front.json
+++ b/src/presets/hubs/Hope-Pro-5-CL_Front.json
@@ -1,0 +1,13 @@
+{
+  "displayName": "Hope Pro 5 CL",
+  "position": "front",
+  "category": "MTB",
+  "description": "Hope Pro 5 Centerlock front hub",
+  "inputs": {
+    "pitchCircleLeft": "43",
+    "pitchCircleRight": "43",
+    "flangeDistanceLeft": "27",
+    "flangeDistanceRight": "35.6",
+    "spokeHoleDiameter": "2.6"
+  }
+}

--- a/src/presets/hubs/Hope-Pro-5-CL_Rear.json
+++ b/src/presets/hubs/Hope-Pro-5-CL_Rear.json
@@ -1,0 +1,13 @@
+{
+  "displayName": "Hope Pro 5 CL",
+  "position": "rear",
+  "category": "MTB",
+  "description": "Hope Pro 5 Centerlock rear hub",
+  "inputs": {
+    "pitchCircleLeft": "51",
+    "pitchCircleRight": "59",
+    "flangeDistanceLeft": "35",
+    "flangeDistanceRight": "22.6",
+    "spokeHoleDiameter": "2.6"
+  }
+}

--- a/src/presets/hubs/Hope-Pro-5-IS6_Front.json
+++ b/src/presets/hubs/Hope-Pro-5-IS6_Front.json
@@ -1,0 +1,13 @@
+{
+  "displayName": "Hope Pro 5 IS6",
+  "position": "front",
+  "category": "MTB",
+  "description": "Hope Pro 5 IS 6-bolt front hub",
+  "inputs": {
+    "pitchCircleLeft": "58",
+    "pitchCircleRight": "52",
+    "flangeDistanceLeft": "25",
+    "flangeDistanceRight": "34",
+    "spokeHoleDiameter": "2.6"
+  }
+}

--- a/src/presets/hubs/Hope-Pro-5-IS6_Rear.json
+++ b/src/presets/hubs/Hope-Pro-5-IS6_Rear.json
@@ -1,0 +1,13 @@
+{
+  "displayName": "Hope Pro 5 IS6",
+  "position": "rear",
+  "category": "MTB",
+  "description": "Hope Pro 5 IS 6-bolt rear hub",
+  "inputs": {
+    "pitchCircleLeft": "57",
+    "pitchCircleRight": "59",
+    "flangeDistanceLeft": "35",
+    "flangeDistanceRight": "22.6",
+    "spokeHoleDiameter": "2.6"
+  }
+}

--- a/src/presets/rims/Nextie-Premium-2936.json
+++ b/src/presets/rims/Nextie-Premium-2936.json
@@ -1,0 +1,9 @@
+{
+  "displayName": "Nextie Premium 29x36",
+  "category": "MTB",
+  "description": "Nextie Premium 29x36 carbon rim",
+  "inputs": {
+    "erd": "581",
+    "rimOffset": "0"
+  }
+}

--- a/src/presets/rims/Stans-Flow-MK4.json
+++ b/src/presets/rims/Stans-Flow-MK4.json
@@ -1,0 +1,9 @@
+{
+  "displayName": "Stan's Flow MK4 29in",
+  "category": "MTB",
+  "description": "Stan's NoTubes Flow MK4 29in rim",
+  "inputs": {
+    "erd": "600",
+    "rimOffset": "3.0"
+  }
+}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -26,13 +26,51 @@ export const btnGhost =
 /** 破壊的動作。 */
 export const btnDanger = `${btnBase} bg-danger text-on-danger hover:bg-danger-hover`;
 
+/**
+ * CSS customizable select (`appearance: base-select`) が使えるか。
+ * クラス文字列とマークアップの両方をこの 1 つの値で切り替える —— nativeSelect の
+ * `appearance-none` は base-select を打ち消すので、CSS のカスケード順に賭けず
+ * そもそも同じ要素に載せない。レンダリング中に変わらないのでモジュール定数でよい。
+ */
+export const supportsBaseSelect =
+  typeof CSS !== 'undefined' && CSS.supports('appearance', 'base-select');
+
+const selectBase =
+  'w-full min-h-11 rounded-md border border-line-strong bg-surface py-2 pl-3 text-fg ' +
+  'transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus';
+
 // appearance-none はドロップダウンのポップアップまでは変えられない。
 // ポップアップ側は index.css の base 層にある color-scheme が担当する。
 // pr-9 は重ねる ChevronDown のぶんの余白。
-export const nativeSelect =
-  'w-full min-h-11 appearance-none rounded-md border border-line-strong bg-surface py-2 pl-3 pr-9 text-fg ' +
-  'transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus';
+export const nativeSelect = `${selectBase} appearance-none pr-9`;
+
+/**
+ * CSS customizable select (`appearance: base-select`) が使えるときの select。
+ * ポップアップまで自前で描けるので、重ねる ChevronDown も appearance-none も要らない
+ * —— むしろ appearance-none は base-select を打ち消すので入れてはいけない。
+ * 実際の見た目は index.css の `@supports (appearance: base-select)` ブロックが持つ。
+ */
+export const customizableSelect = `${selectBase} pr-3`;
+
+// 見出し行に添える chip 型の select。入力欄ではなく「ここを埋める材料を選ぶ」操作
+// なので、フルワイドの枠付きフィールドにはしない。丸いピルにして一段引かせる。
+const chipBase =
+  'inline-flex min-h-9 max-w-full items-center gap-1.5 rounded-full border border-line bg-surface py-1 pl-3 ' +
+  'text-sm text-fg-muted transition-colors hover:bg-sunken hover:text-fg ' +
+  'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus';
+
+export const nativeSelectChip = `${chipBase} appearance-none pr-8`;
+export const customizableSelectChip = `${chipBase} pr-3`;
 
 /** ネイティブ select に重ねる ChevronDown 用。pointer-events-none が無いとクリックを食う。 */
 export const selectChevron =
   'pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-fg-subtle';
+
+/** グループを持たない単独の見出しラベル (保存名の入力欄など)。 */
+export const sectionHeading = 'mb-3 flex items-center gap-2 text-sm font-semibold text-fg';
+
+/** sectionHeading に添えるアイコン。 */
+export const sectionHeadingIcon = 'h-4 w-4 shrink-0 text-accent';
+
+/** グループの中に置くフィールドラベル。見出しと張り合わないよう一段弱くする。 */
+export const fieldLabel = 'mb-1 block text-sm font-medium text-fg-muted';

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,10 +1,12 @@
-// 共有するスタイル文字列。コンポーネントではなく定数だけを置く。
+// 共有するスタイル文字列。コンポーネントでないものを置く。
 // eslint.config.js の reactRefresh.configs.vite はコンポーネントと非コンポーネントの
 // 混在 export を警告するので、専用モジュールに分けている。
 //
 // 色は必ずセマンティックトークン (bg-surface, text-fg, border-line …) で書くこと。
 // パレット直参照 (bg-slate-800 など) と dark: は使わない —— 色の決定は
 // src/index.css のトークン層に集約されている。
+
+import type { PointerEvent } from 'react';
 
 const btnBase =
   'inline-flex min-h-11 items-center justify-center gap-2 rounded-md px-4 py-2 font-medium transition-colors ' +
@@ -34,6 +36,39 @@ export const btnDanger = `${btnBase} bg-danger text-on-danger hover:bg-danger-ho
  */
 export const supportsBaseSelect =
   typeof CSS !== 'undefined' && CSS.supports('appearance', 'base-select');
+
+/**
+ * 開いているピッカーを、トリガーの再タップで閉じるための保険。
+ * customizable select を使う select には必ず onPointerDown で付けること
+ * (スタイルではないがこのファイルに置く —— supportsBaseSelect の分岐と
+ * 必ず対で使うもので、離すと片方だけ付け忘れる)。
+ *
+ * Chrome の customizable select は、開いた状態でトリガーを叩いたとき
+ * タッチだと何も起きない (Chrome 151 で確認)。素の
+ * `appearance: base-select` だけを持つ select でも再現するので、
+ * このアプリの CSS・マークアップ・画面幅とは無関係なブラウザ側の穴。
+ * ピッカーが画面を覆うモバイルでは「閉じる手段がない」——
+ * 消すためだけに適当な項目を選ばされる —— という詰みとして出る。
+ *
+ * pointerdown の既定動作を止めるとポップオーバーの light-dismiss が走り、
+ * トリガーを叩いても素直に閉じるようになる。
+ *
+ * ポインタの種類では分けない。閉じるという結果は変わらず、
+ * 「マウスなら大丈夫」を前提にした分岐は入力手段が混ざる端末
+ * (タッチ対応ノート PC など) で穴になる。
+ *
+ * option の上では止めないこと —— 止めると選択そのものが効かなくなる。
+ * ピッカーの中身は select の子なので、イベントはここまで上がってくる。
+ * optgroup の見出しとピッカーの余白も同じくここへ来る (前者は optgroup、
+ * 後者は select が target) が、こちらは止めても閉じない —— light-dismiss は
+ * ピッカーの外を叩いたときだけ走るため。実測で確認済み。
+ */
+export const dismissOpenPicker = (event: PointerEvent<HTMLSelectElement>) => {
+  if ((event.target as Element).closest('option') !== null) return;
+  if (event.currentTarget.matches(':open')) {
+    event.preventDefault();
+  }
+};
 
 const selectBase =
   'w-full min-h-11 rounded-md border border-line-strong bg-surface py-2 pl-3 text-fg ' +

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -54,8 +54,12 @@ export const customizableSelect = `${selectBase} pr-3`;
 
 // 見出し行に添える chip 型の select。入力欄ではなく「ここを埋める材料を選ぶ」操作
 // なので、フルワイドの枠付きフィールドにはしない。丸いピルにして一段引かせる。
+//
+// 幅は中身ではなく外側の枠が決める (w-full)。選んだプリセット名の長さでチップが
+// 伸び縮みすると、見出し行に収まらなくなった瞬間に折り返して行数が変わり、
+// 選択のたびにレイアウトが跳ねる。溢れた名前は省略記号に落とす。
 const chipBase =
-  'inline-flex min-h-9 max-w-full items-center gap-1.5 rounded-full border border-line bg-surface py-1 pl-3 ' +
+  'flex w-full min-h-9 items-center gap-1.5 rounded-full border border-line bg-surface py-1 pl-3 ' +
   'text-sm text-fg-muted transition-colors hover:bg-sunken hover:text-fg ' +
   'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus';
 


### PR DESCRIPTION
Closes #74

ハブとリムを個別にプリセットから選べるようにしました。手持ちの部品同士でも、まだ組んだ
ことのない組み合わせ（例: Hope Pro 5 CL リア + Stan's Flow MK4）をその場で試算できます。

既存 6 ファイルのハブの数値は組み合わせをまたいで完全に一致していたので、新しい実測値は
必要なく、そのまま部品に分解できました。既存の全体プリセットは変更していません。

## 追加データ

| ディレクトリ | 内容 |
|---|---|
| `src/presets/hubs/` | Hope Pro 5 CL / IS6 × フロント / リア の 4 件 |
| `src/presets/rims/` | Nextie Premium 29x36、Stan's Flow MK4 29in の 2 件 |

担当項目の切り分けは入力フォームの区画と同じです。リム = ERD / リムオフセット、
ハブ = PCD / フランジ距離 / スポーク穴径。スポーク本数とクロス数は「ハブとリムの穴数が
一致して初めて決まる」組み方側の値なので部品には含めていません（同じハブが 28H/32H で
存在しうるため）。

## セレクトは入力値の鏡

選択状態を state で持たず、今の入力値に一致する定義を毎回導出して value にしています。
これだけで同期処理なしに次が成り立ちます（#71 の方針に沿い `useEffect` も使いません）。

| 操作 | ホイール | ハブ | リム |
|---|---|---|---|
| ホイールを選ぶ | 点灯 | **自動点灯** | **自動点灯** |
| リムだけ差し替える | **一致する組み合わせへ / 無ければ消灯** | 点灯のまま | 新しいリム |
| フランジ距離を手で直す | **消灯** | **消灯** | 点灯のまま |

これに伴い `selectedPreset` state と 4 箇所の `setSelectedPreset('')` を削除しました。

**挙動変更**: 保存済み計算や JSON インポートで読み込んだ値がプリセットと一致する場合、
従来は必ず空欄になっていたのが点くようになります。

## UI

プリセットは入力欄ではなく「ここを埋める材料の指定」なので、フルワイドのセレクトを積まず、
各見出し行の右にチップとして添えました。

見た目は **CSS customizable select (`appearance: base-select`)** で作っています。
ネイティブ `<select>` のままなのでキーボード操作・スクリーンリーダ・モバイルの UI は
ブラウザ実装が担当し、ARIA を手で組む必要がありません（`SegmentedControl.tsx` に
記録されている方針と同じ）。非対応ブラウザは `CSS.supports()` の定数ひとつで
クラス文字列もマークアップも従来のものへ落ちます（実機で両経路を確認済み）。

- ハブは `position` で **フロント / リア** の optgroup に分割し、前後の取り違えを防ぐ
- 展開時は各行に寸法の要約を添える（`<option>` の子要素ではなく `data` 属性から
  `::after` + `attr()` で描画。子要素にすると React の DOM ネスト検証に引っかかり、
  非対応ブラウザではテキストが連結されて潰れる。擬似要素は畳んだ状態に複製されないので、
  閉じたチップは何もしなくても名前だけの 1 行になる）
- 見出しの右にチップを置くため `FieldGroup` を `fieldset`/`legend` から
  `role="group"` + `aria-labelledby` に変更（`<legend>` はキャプションとして特別に描かれ
  grid/flex のアイテムにならず、chip を legend の中に入れるとグループのアクセシブル名に
  選択中の部品名が混ざってしまうため）
- 見た目の一貫性のため、ホイール比較と言語切替のセレクトも同じ描画に統一。
  比較のロジック・id 体系・`onChange` には触れていません

## テスト

全体プリセットと部品は同じ数値を重複して持つため、ずれたら落ちるテストを追加しました
（`src/presetData.test.ts`）。対応付けはファイル名の規約でとります。

1. **整合性** — 各全体プリセットのハブ / リム項目が、対応する部品の値と一致する
2. **妥当性** — 全部品が担当項目を漏れなく持ち有限の数値、ハブは `position` が有効
3. **一意性** — 同じ数値の定義が 2 つ無い（導出型セレクトは最初の一致しか表示できない）
4. **配置** — 部品ファイルが `presets/` 直下に紛れ込んでいない

不正な部品ファイルは黙って捨てず、既存のプリセット読み込みエラーと同じバナーに合流させます。

## 確認したこと

- `pnpm test` (12 件) / `pnpm lint` / `pnpm build` すべて通過
- `import.meta.glob('./presets/*.json')` がサブディレクトリを拾っていないこと
  （ホイールの選択肢は 6 件のまま、コンソールにエラー無し）
- 上の表の 4 パターンすべての挙動
- 全体プリセットに存在しない **Hope Pro 5 CL(リア) + Stan's Flow MK4** の試算
- base-select 対応・非対応の両経路、ライト / ダーク両テーマ、375px 幅
- ホイール比較の候補に部品が混入していないこと

## 既知の注意点

開発ビルドのコンソールに、React の DOM ネスト検証による警告が 1 本出ます
（`<button> cannot be a child of <select>`）。customizable select がまだ React 側の
ルールに反映されていないためで、本番ビルドでは出ず、SSR もしていないので実害はありません。
畳んだ状態の省略表示を制御するには `<button><selectedcontent>` が必要で、ブラウザが
自動生成するボタンは author 側の CSS から掴めないため、この形にしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
