### PR TITLE
fix(ui): PCD ラベルの死んだレスポンシブ出し分けを畳む (#78)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1713,10 +1713,7 @@ const SpokeLengthCalculator: React.FC = () => {
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
                   <div className="flex items-center gap-1 mb-1">
-                    <label className="block text-sm font-medium text-fg-muted">
-                      <span className="md:hidden">{t('input.pcdLeft')}</span>
-                      <span className="hidden md:block">{t('input.pcdLeft')}</span>
-                    </label>
+                    <label className="block text-sm font-medium text-fg-muted">{t('input.pcdLeft')}</label>
                     <HelpButton topic="pcd" onOpen={setHelpTopic} />
                   </div>
                   <NumberInput
@@ -1734,10 +1731,7 @@ const SpokeLengthCalculator: React.FC = () => {
                 </div>
                 <div>
                   <div className="flex items-center gap-1 mb-1">
-                    <label className="block text-sm font-medium text-fg-muted">
-                      <span className="md:hidden">{t('input.pcdRight')}</span>
-                      <span className="hidden md:block">{t('input.pcdRight')}</span>
-                    </label>
+                    <label className="block text-sm font-medium text-fg-muted">{t('input.pcdRight')}</label>
                     <HelpButton topic="pcd" onOpen={setHelpTopic} />
                   </div>
                   <NumberInput


### PR DESCRIPTION
Closes #78

## 概要

`src/App.tsx` の PCD [左] / PCD [右] のラベルが、**同じ翻訳キー**を `md:hidden` と
`hidden md:block` の 2 つの `<span>` で出し分けていた。中身が同じなので何も切り替わっておらず、
「狭い画面では短い表記にしている」と誤読させるだけのノイズだった。

## 変更

2 つの `<span>` を畳み、テキストを `<label>` に直接置いた。

```diff
-<label className="block text-sm font-medium text-fg-muted">
-  <span className="md:hidden">{t('input.pcdLeft')}</span>
-  <span className="hidden md:block">{t('input.pcdLeft')}</span>
-</label>
+<label className="block text-sm font-medium text-fg-muted">{t('input.pcdLeft')}</label>
```

これで ERD (`src/App.tsx:1655`) / リムオフセット (`src/App.tsx:1673`) /
フランジ距離 (`src/App.tsx:1755`, `src/App.tsx:1773`) のラベルと構造が揃う。
副次的に `md` (48rem) ブレークポイントが `src/` から完全に消え、
このアプリのブレークポイントは `sm` のみになる。

## 短縮キーを足す案を採らなかった理由

issue には「本来は狭い画面で短い表記にしたかったのなら `input.pcdLeftShort` を足す」という
選択肢も挙がっていたが、採らなかった。隣の `input.flangeDistanceLeft`
(`フランジ距離 [左] (mm)`) は `pcdLeft` (`PCD [左] (mm)`) より**長い**のに出し分けを一切
持っていない。PCD だけ短縮が必要という設計意図は存在しないと判断した。

## 触っていないもの

- `htmlFor` は足していない。隣接ラベルも持っておらず、この論点は `src/App.tsx:1816-1819` の
  コメントで別途意図的に扱われている。今回のスコープ外。
- `src/locales/{en,ja}.json` は変更なし。
- `src/App.tsx:1921-1922` (`buttons.jsonShort` / `buttons.jsonDisplay`) は `sm:` で別キーを
  出し分けている正しいコードなので触っていない。

## 検証

- `pnpm lint` — 通過
- `pnpm build` (`tsc -b && vite build`) — 通過
- `pnpm test` — 12 件全通過 (ただし対象は presetData / rimOffset / thirdPartyNotices のみで
  App.tsx はカバー外)
- `rg -n "\bmd:" src/` — **0 件** (変更前は今回消した 4 行のみ)
- 目視 (dev server + playwright-cli): デスクトップ 1440px / 狭幅 390px、日英両ロケールで、
  PCD ラベルが**未変更の隣接ラベル (ERD / リムオフセット / フランジ距離) と同一のスタイル・
  配置**でレンダリングされることを確認。同一フレーム内に未変更のラベルが写っているため、
  before/after の対比なしに退行がないことを確認できる。

## 別 issue にするもの

`pitchCircleLeft` / `pitchCircleRight` の placeholder が `input.flangeLeftPlaceholder` /
`input.flangeRightPlaceholder` を参照している (`src/App.tsx:1728`, `src/App.tsx:1746`)。
`input.pcdLeftPlaceholder` / `pcdRightPlaceholder` が存在するのに使われていない。
値が同一 (`左側` / `Left Side`) なので表示上の不具合はないが、キーの取り違えの可能性が高い。
本 PR のスコープ外として #81 に切り出した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
