### PR TITLE
fix(dev): pnpm devをADB reverse対応のIPv4待受に固定する

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,10 @@ import tailwindcss from '@tailwindcss/vite'
 export default defineConfig(({ command }) => ({
   base: command === 'serve' ? '/' : '/spoke-length-calculator/',
   plugins: [react(), tailwindcss()],
+  server: {
+    host: '127.0.0.1',
+    strictPort: true,
+  },
   // Tailwind v4 は @tailwindcss/vite 経由で Lightning CSS を使うため PostCSS を必要としない。
   // 明示的に空にしておかないと、Vite が親ディレクトリを遡って postcss.config を探し、
   // 見つけた設定（例: git worktree を親リポジトリ配下に置いた場合の v3 用設定）で


### PR DESCRIPTION
Vite開発サーバーを127.0.0.1へ固定し、strictPortを有効化します。検証: pnpm lint / pnpm test / pnpm build、127.0.0.1待受・HTTP 200、5173競合時の明示エラー、ADB reverse実機ポート接続。端末がロック中だったためChromeの画面表示のみ未確認です。Closes #79