### PR TITLE
fix(ui): プリセット select の畳んだ表示を言語切替に追従させる

### DIFF
--- a/src/components/PresetSelect.tsx
+++ b/src/components/PresetSelect.tsx
@@ -44,7 +44,7 @@ interface PresetSelectProps {
 // 寸法の要約は子要素ではなく data 属性で渡し、CSS の ::after + attr() で描く。
 // <option> の中に <span> を置くと React の DOM ネスト検証に引っかかるうえ、
 // base-select 非対応のブラウザではテキストが連結されて 1 行に潰れる。
-// ::after なら畳んだ状態にも複製されないので、閉じたときは自動的に名前だけになる。
+// 畳んだ状態には item.name だけを出すので、要約は開いたときにしか現れない。
 const renderItems = (items: PresetSelectItem[]) => (
   items.map(item => (
     <option key={item.id} value={item.id} data-spec={item.spec}>

--- a/src/components/PresetSelect.tsx
+++ b/src/components/PresetSelect.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown } from 'lucide-react';
-import { Fragment, createElement } from 'react';
+import { Fragment } from 'react';
 
 import {
   customizableSelect,
@@ -11,23 +11,6 @@ import {
   selectChevron,
   supportsBaseSelect,
 } from '../styles';
-
-/**
- * 畳んだ状態を自分で組むための <button><selectedcontent>。
- *
- * 省略するとブラウザが同等のボタンを起こすが、それは author 側の CSS から掴めず、
- * 長いプリセット名がチップからはみ出しても省略記号にできない。自前で置けば
- * min-width:0 と text-overflow を効かせられる。
- *
- * <selectedcontent> は @types/react にまだ無い要素。JSX で書くには
- * JSX.IntrinsicElements の拡張が要り、それには namespace が必要で eslint の
- * no-namespace に触れるので createElement で作る。
- *
- * なお React の DOM ネスト検証は <select> の子に <button> を許さず、開発ビルドで
- * 警告を 1 本出す (customizable select がまだ React 側に反映されていないため)。
- * 本番ビルドでは出ず、SSR もしていないので実害はない。
- */
-const SelectedContent = () => createElement('selectedcontent');
 
 export interface PresetSelectItem {
   id: string;
@@ -87,6 +70,12 @@ export function PresetSelect({
     ? `${isChip ? customizableSelectChip : customizableSelect} preset-select`
     : (isChip ? nativeSelectChip : nativeSelect);
 
+  // 畳んだ状態に出るラベル。どの項目にも一致しない value が来たらブラウザは何も
+  // 選ばないので、プレースホルダに倒す (空欄よりは「まだ選んでいない」と読める)。
+  const selectedLabel = value === ''
+    ? placeholder
+    : groups.flatMap(group => group.items).find(item => item.id === value)?.name ?? placeholder;
+
   const select = (
     // chip の枠は行の余りを埋めるだけ (flex-1 + 上限)。中身の長さに幅を決めさせない
     // ので、何を選んでもチップの位置と大きさは初期状態のまま動かない。
@@ -99,9 +88,22 @@ export function PresetSelect({
         aria-label={isChip ? label : undefined}
         className={selectClass}
       >
+        {/* 畳んだ状態を自分で組む。省略するとブラウザが同等のボタンを起こすが、
+            それは author 側の CSS から掴めず、長いプリセット名がチップから
+            はみ出しても省略記号にできない。自前で置けば min-width:0 と
+            text-overflow を効かせられる。
+
+            中身はブラウザ任せの <selectedcontent> ではなく自分で描く。あれは
+            選択中の option を複製する要素で、複製が走るのは挿入時と選択が
+            変わったときだけ —— 選択はそのままで option のテキストだけが
+            変わる言語切替では、旧言語の複製が残る (実測済み)。
+
+            なお React の DOM ネスト検証は <select> の子に <button> を許さず、
+            開発ビルドで警告を 1 本出す (customizable select がまだ React 側に
+            反映されていないため)。本番ビルドでは出ず、SSR もしていないので実害はない。 */}
         {supportsBaseSelect && (
           <button>
-            <SelectedContent />
+            <span>{selectedLabel}</span>
           </button>
         )}
         {/* プレースホルダを disabled にしてはいけない。'' は初期状態でも手編集後でも

--- a/src/index.css
+++ b/src/index.css
@@ -245,7 +245,7 @@
     appearance: base-select;
   }
 
-  /* 閉じた状態。<button><selectedcontent> を自前で置いてあるので、
+  /* 閉じた状態。<button><span> を自前で置いてあるので、
      長いプリセット名は省略記号に落として矢印を必ず残す。 */
   .preset-select {
     display: flex;
@@ -267,7 +267,7 @@
     text-align: start;
   }
 
-  .preset-select selectedcontent {
+  .preset-select>button>span {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
Closes #86

## 問題

言語を切り替えても、プリセット選択チップの畳んだ表示が切替前の言語のまま残る。
リロードすると直る。en → ja でも ja → en でも起きる。

React 側は正しく、`<option value="">` のテキストは切替と同時に更新されている。
壊れているのは Chrome の customizable select 側で、`<selectedcontent>` は選択中の
option を**複製**する要素であり、複製が走るのは挿入時と選択が変わったときだけ。
未選択時に選択されているのはプレースホルダなので、翻訳が変わった瞬間に複製だけが
古い言語で取り残される。

ja 切替直後の実測 (修正前):

```
{ id: "preset",    opt0: "ホイールを選ぶ", selectedcontent: "Pick a wheel" }
{ id: "rimPreset", opt0: "リムを選ぶ",     selectedcontent: "Pick a rim"   }
{ id: "hubPreset", opt0: "ハブを選ぶ",     selectedcontent: "Pick a hub"   }
```

## 却下した案 —— `key` で `<selectedcontent>` を作り直す

効かない。実測で、新品の `selectedcontent` を挿し込んだ後に option のテキストを
変更しても 2 フレーム後まで追従しなかった —— **複製は挿入した瞬間に確定し、
以後 option のテキスト変更を一切追わない**。
加えて React のコミット順は `<button><selectedcontent>` (select の第 1 子) が先で
`<option>` のテキスト更新が後なので、作り直した要素が掴むのは必ず旧言語になる。

`selectedIndex` の再代入で再複製を促す案 (ref + useEffect) も動くが、小細工が残るので採らない。

## 変更

`<selectedcontent>` をやめ、畳んだ状態のラベルを React が直接描く。複製という経路
自体が無くなるので、この種のズレが構造的に起きなくなる。`<selectedcontent>` が
`@types/react` に無いための `createElement` 回避も丸ごと消えた。

- `src/components/PresetSelect.tsx` — `SelectedContent` ヘルパを削除、`selectedLabel` を
  算出して `<button><span>{selectedLabel}</span></button>` を描く
- `src/index.css` — 省略記号の当て先を `.preset-select selectedcontent` から
  `.preset-select>button>span` に移す

`PresetSelect` の中だけで閉じるので、呼び出し側 (入力欄の chip 3 つ + 比較の field 2 つ)
は無変更で全部直る。翻訳 JSON も触っていない。

なお `value` がどの option にも一致しない場合、従来はブラウザが何も選ばず空欄になったが、
変更後はプレースホルダが出る。空欄より妥当と判断した。

## 検証

`pnpm lint` / `pnpm test` (12 pass) / `pnpm build` 通過。
起動中の dev サーバに playwright-cli を当てて実機確認:

- **リロードせず** en → ja → en と往復し、各段で `strayClones === 0` かつ
  3 チップすべてで `button > span` のテキスト === `options[0].text`
- 比較セクション (`compareWheelA` / `compareWheelB`, variant=field) も同様に追従
- プリセット選択状態で言語を切り替えても部品名が正しく残る
- `.preset-select>button>span` の computed style が
  `display:block / overflow:hidden / text-overflow:ellipsis / white-space:nowrap` で当たる
- チップ寸法 256 × 36px は従来と同一。長い名前で `scrollWidth 608 > clientWidth 211` と
  省略記号が効く
- 実マウスで picker を開く → option を選ぶ → 閉じて入力欄が埋まる、を確認。
  再タップで閉じる `dismissOpenPicker` も生きている
- ダークモード + 日本語で目視確認

コンソールの `In HTML, %s cannot be a child of <%s>` は `<button>` を `<select>` の子に
置いていることに対する React の既存警告で、この変更の前後で変わらない (コード内に注記済み)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsCUeWUVDovCuLswLo4ELm