### PR TITLE
fix(i18n): PCD 入力欄の placeholder を PCD 用キーに差し替え (#81)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1723,7 +1723,7 @@ const SpokeLengthCalculator: React.FC = () => {
                     min={1}
                     max={100}
                     error={visibleFieldErrors.pitchCircleLeft}
-                    placeholder={t('input.flangeLeftPlaceholder')}
+                    placeholder={t('input.pcdLeftPlaceholder')}
                   />
                   <FieldError id="pitchCircleLeft-error" message={visibleFieldErrors.pitchCircleLeft} />
                 </div>
@@ -1741,7 +1741,7 @@ const SpokeLengthCalculator: React.FC = () => {
                     min={1}
                     max={100}
                     error={visibleFieldErrors.pitchCircleRight}
-                    placeholder={t('input.flangeRightPlaceholder')}
+                    placeholder={t('input.pcdRightPlaceholder')}
                   />
                   <FieldError id="pitchCircleRight-error" message={visibleFieldErrors.pitchCircleRight} />
                 </div>


### PR DESCRIPTION
Closes #81

## 概要

PCD 入力欄 (`pitchCircleLeft` / `pitchCircleRight`) の `placeholder` が、PCD 用の翻訳キーではなく
**フランジ距離用のキー** を参照していた。PCD 用の `input.pcdLeftPlaceholder` /
`input.pcdRightPlaceholder` は `src/locales/{en,ja}.json` に定義されているのに未参照の死んだキーに
なっていた。issue の**案 A** (PCD 用キーを使う) を採用。

## 変更内容

`src/App.tsx` の 2 行のみ。

| 対象 `NumberInput` | 変更前 | 変更後 |
| --- | --- | --- |
| `id="pitchCircleLeft"` | `t('input.flangeLeftPlaceholder')` | `t('input.pcdLeftPlaceholder')` |
| `id="pitchCircleRight"` | `t('input.flangeRightPlaceholder')` | `t('input.pcdRightPlaceholder')` |

- `flangeDistanceLeft` / `flangeDistanceRight` の flange 系キー参照は**正しいので触っていない**
- `src/locales/{en,ja}.json` は**変更なし** (4 キーとも既に定義済み)
- レンダリング構造・props・state・`t()` の呼び出し位置は不変。再レンダリング特性も変わらない

## 挙動への影響: なし

4 キーの値は現時点ですべて同一 (`左側`/`右側`、`Left Side`/`Right Side`) のため、**画面表示は
修正前後で完全に同一**。変わるのは「どのキーを引いているか」だけの純粋なリファクタリング。

得られるもの: 今後 PCD 側だけ文言を変えられる / フランジ側を編集しても PCD が巻き添えにならない。

## 検証

値が同一なので「画面に『左側』と出る」確認は前後で同じ結果になり証拠にならない。以下で検証した。

1. **参照の静的確認** — `rg -n "pcd(Left|Right)Placeholder|flange(Left|Right)Placeholder" src/`
   pcd 系が PCD 入力欄 2 箇所に、flange 系がフランジ距離入力欄 2 箇所のみに出ることを確認。
   `src/` 内の未参照 placeholder キーは解消。
2. **`pnpm build` (tsc + vite) / `pnpm lint` / `pnpm test` (12 pass)** すべて green
3. **配線の実証** — dev サーバー上で `en.json` の `pcdLeftPlaceholder` を一時的に
   `PROBE-PCD-LEFT` に変更し、DOM の `placeholder` 属性を確認:

   | | プローブ前 | プローブ中 |
   | --- | --- | --- |
   | `pitchCircleLeft` | `Left Side` | **`PROBE-PCD-LEFT`** |
   | `pitchCircleRight` | `Right Side` | `Right Side` |
   | `flangeDistanceLeft` | `Left Side` | `Left Side` (巻き添えなし) |
   | `flangeDistanceRight` | `Right Side` | `Right Side` |

   PCD [左] だけが追従し、フランジ距離 [左] は変化しないことを確認。プローブは revert 済み
   (差分は `src/App.tsx` の 2 行のみ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
