### PR TITLE
fix(ui): プリセット chip の font-size をブラウザ間で 14px に揃える (#90)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -237,7 +237,9 @@
    ライト / ダーク両対応になる (dark: もパレット直参照も要らない)。
 
    @layer に入れない —— 素のセレクタを Tailwind のユーティリティ層より後に置いて、
-   カスケード順の綱引きを避ける。 */
+   カスケード順の綱引きを避ける。裏返すと、ここに書いた宣言は同じプロパティの
+   ユーティリティを詳細度に関係なく必ず打ち消す。ユーティリティ側に決めさせたい
+   プロパティ (font-size など) はこのブロックに書かないこと。 */
 @supports (appearance: base-select) {
 
   .preset-select,
@@ -246,13 +248,18 @@
   }
 
   /* 閉じた状態。<button><span> を自前で置いてあるので、
-     長いプリセット名は省略記号に落として矢印を必ず残す。 */
+     長いプリセット名は省略記号に落として矢印を必ず残す。
+
+     font も font-size も書かない。ここはレイヤ外なので書けば text-sm などの
+     text-* ユーティリティを無言で飲み、base-select 対応ブラウザだけ文字が
+     大きくなる (#90)。フォントの継承は Tailwind preflight の @layer base にある
+     select への font: inherit が既に担っていて、そちらはユーティリティ層より
+     前なので font-size だけをユーティリティに明け渡せる。 */
   .preset-select {
     display: flex;
     align-items: center;
     gap: 0.5rem;
     text-align: start;
-    font: inherit;
   }
 
   .preset-select>button {


### PR DESCRIPTION
Closes #90

## 何が起きていたか

畳んだプリセット chip の computed font-size がブラウザで割れていた。

| ブラウザ | `appearance: base-select` | 修正前 | 修正後 |
|---|---|---|---|
| Chrome / Android Chrome | 対応 | 16px | **14px** |
| iOS Safari / Firefox | 非対応 | 14px | 14px (変化なし) |

`src/index.css` の `@supports (appearance: base-select)` ブロックは意図的に `@layer` の
外にあり、レイヤ外の宣言は詳細度に関係なくユーティリティ層を必ず打ち消す。そのため
`.preset-select { font: inherit }` の `font` 一括指定が `chipBase` の `text-sm` を丸ごと飲み、
base-select 対応ブラウザだけ body 継承の 16px になっていた。

## なぜ 14px に倒したか

`text-sm` は `chipBase` (`src/styles.ts:98`) だけでなく `languageSelectClass`
(`src/App.tsx:165-166`) の **base-select 分岐とネイティブ分岐の両方に** 書かれている。
同じ要素に対して 2 経路で 14px を指定しており、意図は 14px で確定。16px 側が事故。

加えて chip が添う `FieldGroup` の見出しは `text-sm font-semibold` (`src/App.tsx:987`) で、
16px の chip は従属すべき見出しを上回ってしまっていた。

## 変更

`.preset-select` から `font: inherit;` を削除。**longhand へばらす必要はなかった** ——
Tailwind v4 の preflight が `@layer base` の中で `select` に `font: inherit` を持っており
(`node_modules/tailwindcss/index.css:790-804`)、`@layer base` はユーティリティ層より前なので、
消すだけで font-family は Inter を継承したまま font-size だけが `text-sm` に戻る。

`.preset-select > button` 側の `font: inherit` は残した。この button は className を持たず
競合するユーティリティが無いので、14px になった select からそのまま継承する。

あわせて再発防止のコメントを 2 箇所に追加 (実質の変更が 1 行削除なので、コメントの方が本体)。

## 影響範囲

**Chrome / Android Chrome で 16px → 14px:**
- `#preset` / `#rimPreset` / `#hubPreset` の chip
- **ヘッダーの言語切替 select** — issue では挙げていなかったが `preset-select` + `text-sm` を
  持つので同時に直る
- ピッカー内 `option` のテキスト。`optgroup` 見出しと `[data-spec]::after` は 0.75rem 固定、
  `option` の padding も rem なので不変。行の高さは 16px/24px → 14px/20px で約 40px → 36px に
  縮む (どちらも元から 44px 未満なので新種の問題ではない)。打ち消す `font-size` は足していない
  —— 今回消したバグの型をそのまま復活させるため

**変化なし:** iOS Safari / Firefox (元から 14px)、CompareWheels の `variant="field"`
(`customizableSelect` は text-* を持たない)、畳んだ chip の幅と高さ (`min-h-9` が
14px/20px + `py-1` を上回る)。#84 #85 #86 #87 の「選択名の長短で幅が動かない」不変条件には
触れていない。

## 検証

base-select 対応の Chromium 2 種 (アプリ内ブラウザ / Playwright Chromium) で
`CSS.supports('appearance','base-select') === true` を確認したうえで、`.preset-select` を
**クラスで** 列挙して計測 (言語切替 select は `id` を持たないため id ベースだと漏れる)。

| 要素 | font-size | font-family |
|---|---|---|
| `#preset` / `#rimPreset` / `#hubPreset` | 14px | Inter |
| 言語切替 (id なし) | 14px | Inter |
| `#compareWheelA` / `#compareWheelB` (field) | **16px** | Inter |

因果の確認として、削除した `font: inherit` を JS で注入し直すと全て 16px に復帰、
外すと 14px に戻ることも確認した。

そのほか:
- ピッカーを開いた見た目 (option / optgroup / 寸法副題 / ✓ / 150ms 回転) を目視、従来どおり
- ライト 1440px / ダーク 375px で崩れなし
- `pnpm lint` / `pnpm build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
