### PR TITLE
docs(select): dismissOpenPicker の検証済み範囲を実測に合わせる (#91)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -290,6 +290,10 @@
     background: var(--color-surface);
     box-shadow: 0 12px 32px -12px rgb(0 0 0 / 0.35);
     padding: 0.25rem;
+    /* この上限は見た目のためだけではない。WebKit にはトリガーの再タップで閉じる
+       経路が無く (styles.ts の dismissOpenPicker を参照)、閉じる手段が
+       「ピッカーの外をタップする」しか残らない。max-height を緩めて
+       ピッカーが画面を覆うと、その的ごと消えて閉じられなくなる。 */
     max-height: 20rem;
     overflow-y: auto;
     /* トップレイヤの要素なので、display と overlay も allow-discrete で繋がないと

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -68,10 +68,16 @@ export const supportsBaseSelect =
  * index.css の ::picker(select) の max-height なので、あれを緩めると
  * WebKit では本当に閉じられなくなる。
  *
- * base-select 非対応のブラウザ (iOS 18.7 の実機など) には、supportsBaseSelect の
- * 分岐でこのハンドラがそもそも付かない。そこに出るのは OS のネイティブメニューで、
- * 位置も閉出も OS のもの —— トリガーに重なって再タップできないのも、
- * アプリからは動かせないそちら側の話 (#88 / #91)。
+ * base-select 非対応のブラウザには、supportsBaseSelect の分岐でこのハンドラが
+ * そもそも付かない。そこに出るのは OS のネイティブメニューで、位置も閉出も
+ * OS のもの —— トリガーに重なって再タップできないのも、アプリからは動かせない
+ * そちら側の話 (#88 / #91)。
+ *
+ * iOS Safari は 26.6 の実機でも `CSS.supports('appearance','base-select')` が
+ * false で、こちらの経路に落ちる (実機で実測)。Playwright の WebKit 26.5
+ * デスクトップビルドは true を返すので、あれを iOS の代用にはできない。
+ * なお同じ実機の UA は `CPU iPhone OS 18_7` と名乗る —— OS トークンは実際の
+ * バージョンと一致しない。判定は必ず CSS.supports で行うこと。
  *
  * ポインタの種類では分けない。閉じるという結果は変わらず、
  * 「マウスなら大丈夫」を前提にした分岐は入力手段が混ざる端末

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -47,11 +47,31 @@ export const supportsBaseSelect =
  * タッチだと何も起きない (Chrome 151 で確認)。素の
  * `appearance: base-select` だけを持つ select でも再現するので、
  * このアプリの CSS・マークアップ・画面幅とは無関係なブラウザ側の穴。
- * ピッカーが画面を覆うモバイルでは「閉じる手段がない」——
- * 消すためだけに適当な項目を選ばされる —— という詰みとして出る。
  *
  * pointerdown の既定動作を止めるとポップオーバーの light-dismiss が走り、
  * トリガーを叩いても素直に閉じるようになる。
+ *
+ * ここまでが効くのは Chrome だけ。WebKit では空振りする
+ * (Playwright の WebKit 26.5 + iPhone 15 で実測。実 Safari ではない):
+ *
+ * - 再タップの pointerdown は届き `preventDefault()` も通る (document で
+ *   拾った defaultPrevented が true) が、ピッカーは開いたまま。
+ *   「既定動作の抑止 → light-dismiss」という連鎖を WebKit は持たない。
+ * - 代わりに足せる経路も無い。`hidePicker()` 相当は存在せず
+ *   ('hidePicker' in HTMLSelectElement.prototype は Chrome も WebKit も false)、
+ *   `blur()` は効かず (開いている間 activeElement は既に option)、
+ *   touchstart の抑止も空振り、mousedown はタッチでは発火しない。
+ *
+ * だから WebKit 向けの分岐は入れていない。合成キーイベントのような
+ * 「閉じたように見せる」手も入れない。WebKit で閉じる手段はピッカーの外を
+ * タップすることと Escape (どちらも実測)。その「外」を残しているのが
+ * index.css の ::picker(select) の max-height なので、あれを緩めると
+ * WebKit では本当に閉じられなくなる。
+ *
+ * base-select 非対応のブラウザ (iOS 18.7 の実機など) には、supportsBaseSelect の
+ * 分岐でこのハンドラがそもそも付かない。そこに出るのは OS のネイティブメニューで、
+ * 位置も閉出も OS のもの —— トリガーに重なって再タップできないのも、
+ * アプリからは動かせないそちら側の話 (#88 / #91)。
  *
  * ポインタの種類では分けない。閉じるという結果は変わらず、
  * 「マウスなら大丈夫」を前提にした分岐は入力手段が混ざる端末
@@ -61,7 +81,7 @@ export const supportsBaseSelect =
  * ピッカーの中身は select の子なので、イベントはここまで上がってくる。
  * optgroup の見出しとピッカーの余白も同じくここへ来る (前者は optgroup、
  * 後者は select が target) が、こちらは止めても閉じない —— light-dismiss は
- * ピッカーの外を叩いたときだけ走るため。実測で確認済み。
+ * ピッカーの外を叩いたときだけ走るため。Chrome で実測して確認済み。
  */
 export const dismissOpenPicker = (event: PointerEvent<HTMLSelectElement>) => {
   if ((event.target as Element).closest('option') !== null) return;


### PR DESCRIPTION
Closes #91

## 変更

コメントのみ。**挙動は 1 行も変えていない**（`git diff` は全行がコメント）。

- `src/styles.ts` — `dismissOpenPicker` の JSDoc を実測に合わせて改稿
- `src/index.css` — `::picker(select)` の `max-height: 20rem` が持つ役割を注記

## なぜ

`dismissOpenPicker` の JSDoc は Chrome 151 でしか検証されていないのに、「pointerdown の既定動作を止めると light-dismiss が走る」を全ブラウザの挙動のように書いていた。また「ピッカーが画面を覆うモバイルでは閉じる手段がない」という前提も実測と合っていなかった。

## 実測 (Playwright WebKit 26.5 + iPhone 15 / Chrome 151 + Pixel 7。実 Safari ではない)

| 経路 | WebKit 26.5 | Chrome 151 |
|---|---|---|
| トリガー再タップ | **閉じない** | 閉じる |
| ピッカー外タップ | 閉じる | 閉じる |
| Escape | 閉じる | — |

WebKit では再タップの `pointerdown` は届き `preventDefault()` も通る（`defaultPrevented = true`）のにピッカーは開いたまま。「既定動作の抑止 → light-dismiss」の連鎖を WebKit は持たない。

代わりに足せる経路も無かった:

| 候補 | 結果 |
|---|---|
| `hidePicker()` 相当 | `'hidePicker' in HTMLSelectElement.prototype` → false（Chrome も false）。`showPicker` も無い |
| `blur()` / `activeElement.blur()` | 閉じない（開いている間 `activeElement` は既に `option`） |
| `touchstart` の `preventDefault()` | 閉じない |
| `mousedown` の `preventDefault()` | タッチでは `mousedown` が発火しない |

よって WebKit 向けの分岐は**足さない**。合成キーイベントのような「閉じたように見せる」手も入れない。

## 実機の位置づけ

実機（iPhone / **iOS 26.6**）を計測プローブで確認したところ **`CSS.supports('appearance','base-select') = false`**。`dismissOpenPicker` はそもそも付かず、`index.css` の `@supports` ブロックも無効で、出ているのは **iOS ネイティブの select メニュー**（`option` の rect が 0、寸法の副題も出ない）。メニューの位置も閉出も OS のもので、アプリ側に手が無い（#88 と同じ）。外タップでは閉じることを実機ログで確認済み。

つまり **iOS Safari は 26.6 でも base-select 非対応**で、Playwright の WebKit 26.5 デスクトップビルド（`true` を返す）を iOS の代用にはできない。

なお同じ実機の UA は `CPU iPhone OS 18_7 ... Version/26.6` と名乗る。**OS トークンは実際のバージョンと一致しない**ので、判定は必ず `CSS.supports` で行う（この点はコメントにも残した）。

## 検証

```
pnpm lint && pnpm build && pnpm test   # すべて green (テスト 12/12)
```

Playwright で 3 つの chip すべてを退行確認:

- Chrome 151: 再タップで閉じる（**従来の挙動を維持**）／外タップでも閉じる
- WebKit 26.5: 再タップでは閉じない（現状どおり）／外タップで閉じる
- 両方: option をタップして選択できる（`closest('option')` の早期 return が生きている。`value` 更新と ERD 581 の反映を確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
