### PR TITLE
fix(ui): 比較パネルを閉じるときも滑らかに畳む (#95)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1990,7 +1990,7 @@ const SpokeLengthCalculator: React.FC = () => {
               onClick={() => setShowCompare(prev => !prev)}
               aria-expanded={showCompare}
               aria-controls="compare-panel"
-              className={`w-full min-h-11 flex items-center justify-between gap-3 px-5 sm:px-6 py-4 text-left text-lg font-semibold text-fg hover:bg-sunken transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus ${showCompare ? 'rounded-t-xl border-b border-line' : 'rounded-xl'}`}
+              className={`w-full min-h-11 flex items-center justify-between gap-3 px-5 sm:px-6 py-4 text-left text-lg font-semibold text-fg hover:bg-sunken border-b transition-[background-color,border-color,border-radius] duration-200 ease-out motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus ${showCompare ? 'rounded-t-xl border-line' : 'rounded-xl border-transparent'}`}
             >
               <span className="flex items-center gap-2">
                 <ArrowLeftRight aria-hidden="true" className="h-4 w-4 shrink-0 text-accent" />
@@ -1998,24 +1998,47 @@ const SpokeLengthCalculator: React.FC = () => {
               </span>
               <ChevronDown
                 aria-hidden="true"
-                className={`shrink-0 h-4 w-4 text-fg-subtle transition-transform ${showCompare ? 'rotate-180' : ''}`}
+                className={`shrink-0 h-4 w-4 text-fg-subtle transition-transform duration-200 ease-out motion-reduce:transition-none ${showCompare ? 'rotate-180' : ''}`}
               />
             </button>
           </h2>
           {/* 区切りのハイラインはボタン側 (border-b) に置く。パネルに border-t を
-              持たせると fade-in-down の -8px にハイラインごと引きずられ、
-              開く瞬間だけ区切り線がヘッダ行の中を滑り降りて見える */}
-          {showCompare && (
-            <div id="compare-panel" className="p-5 sm:p-6 animate-fade-in-down">
-              <CompareWheels
-                options={wheelOptions}
-                selectedA={compareA}
-                selectedB={compareB}
-                onChangeA={setCompareA}
-                onChangeB={setCompareB}
-              />
+              持たせると畳み込みにハイラインごと引きずられ、開閉の瞬間だけ区切り線が
+              ヘッダ行の中を滑って見える。border-b は開閉で付け外しせず色だけ変える ——
+              1px の出入りでヘッダの高さがガタつくため。
+              パネルはアンマウントせず grid の 0fr/1fr で畳む。消してしまうと閉じる側に
+              トランジションが走らない (#95)。
+              **開く側だけ transition-none にしてあるのは意図的。** 下の
+              useLayoutEffect の scrollIntoView は呼んだ瞬間のスクロール可能範囲に
+              クランプされる。ここが最終要素でフッタが無いので、開くのをアニメにすると
+              まだ縮んだ文書に対してスクロール先が決まってしまい、伸びたパネルの下端が
+              折り返しの下に取り残される (1280x720 実測で 153px)。開く高さは即時に
+              確定させ、フェードだけ子側で見せる */}
+          <div
+            id="compare-panel"
+            className={`grid ${showCompare
+              ? 'grid-rows-[1fr] visible transition-none'
+              : 'grid-rows-[0fr] invisible transition-[grid-template-rows,visibility] duration-200 ease-out motion-reduce:transition-none'}`}
+          >
+            {/* クリップはこの内側だけ。外枠に overflow-hidden を付けられない理由は上記。
+                padding をここではなく子に置くのは、border-box では高さ 0 でも padding が
+                残り、0fr でも箱が開いたままになるため */}
+            <div className="min-h-0 overflow-hidden">
+              <div
+                className={`p-5 sm:p-6 transition-[opacity,translate] duration-200 ease-out motion-reduce:transition-none ${
+                  showCompare ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2'
+                }`}
+              >
+                <CompareWheels
+                  options={wheelOptions}
+                  selectedA={compareA}
+                  selectedB={compareB}
+                  onChangeA={setCompareA}
+                  onChangeB={setCompareB}
+                />
+              </div>
             </div>
-          )}
+          </div>
         </div>
       </div>
 

--- a/src/components/CompareWheels.tsx
+++ b/src/components/CompareWheels.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CircleCheck, TriangleAlert } from 'lucide-react';
 import { compareWheels, type WheelSpec } from '../spokeCompare';
@@ -132,4 +132,7 @@ const CompareWheels: React.FC<Props> = ({ options, selectedA, selectedB, onChang
   );
 };
 
-export default CompareWheels;
+// 畳んでいる間もマウントされたままなので (App の compare-panel を参照)、入力欄を
+// 打つたびに親が再描画されるとここも巻き添えになる。props はどれも参照が安定して
+// いる (options は useMemo、onChange は setState そのもの) ので memo で素通しできる。
+export default memo(CompareWheels);

--- a/src/index.css
+++ b/src/index.css
@@ -104,20 +104,6 @@
      tnum の挙動が一貫しないが Inter は素直で、lang に関係なく桁が揃う。 */
   --font-sans: "Inter", "Noto Sans JP", ui-sans-serif, system-ui, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
-
-  --animate-fade-in-down: fade-in-down 0.2s ease-out;
-
-  @keyframes fade-in-down {
-    0% {
-      opacity: 0;
-      transform: translateY(-8px);
-    }
-
-    100% {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
 }
 
 .dark {


### PR DESCRIPTION
Closes #95

## 背景

比較パネルは `{showCompare && (...)}` で**アンマウント**されていたため、
DOM から消えた要素に exit トランジションが走らず、閉じるときだけ
「ブチッ」と切れていた。開く側は `animate-fade-in-down` (mount 時に発火する
CSS animation) と smooth な `scrollIntoView` が走るので、開閉で
エフェクトが非対称になっていた。

## 変更

- パネルを常時マウントに変え、grid の `0fr → 1fr` で高さを畳む
- `visibility` を同じ尺で遷移させ、畳んでいるあいだのフォーカス到達と
  支援技術への露出を止める。「両端のどちらかが visible なら遷移中は visible」
  の補間規則により、崩れる途中は見えたままになる
- 副次的に `aria-controls="compare-panel"` の参照先が常に存在するようになる
  (従来は閉じている間、参照先が DOM に無かった)
- ヘッダの区切り線と角丸も 200ms に統一。`border-b` は開閉で付け外しせず
  色だけ変える (1px の出入りでヘッダの高さがガタつくため)
- 未使用になった `fade-in-down` の keyframes を削除
- 新設したトランジションはすべて `motion-reduce:` で塞いである

## 開く側だけ `transition-none` にしている理由

`useLayoutEffect` の `scrollIntoView` は**呼んだ瞬間のスクロール可能範囲に
クランプされる**。比較セクションは文書の最終要素でフッタが無いため、
`block: 'start'` は常にクランプされる側にいる。

| 状態 | maxScroll | セクション先頭 |
|---|---|---|
| 閉 | 907 | 1540 |
| 開 | 1091 | 1540 |

開く側もアニメにすると、まだ縮んだ文書 (907) に対してスクロール先が決まり、
その後にパネルが伸びるだけなので下端 153px が折り返しの下に取り残される。
開く高さは即時に確定させ、フェードだけ子要素で見せている。
この経緯はコード側にもコメントとして残した。

## 検証 (Chromium 実測)

| 項目 | 結果 |
|---|---|
| 開: 1 フレーム後のパネル高 | 184px (即確定 / コンテナのトランジション 0 本) |
| 開: スクロール着地 | `scrollTop` 1091 = maxScroll、セクション 441..688px で**全部入る** (変更前と同一) |
| 閉: 高さの推移 | 184 → 135.5 → 102.9 → 78 → … → 0、単調減少・中間値 13 個・200ms で完了 |
| 閉: 崩れる途中の `visibility` | 全フレームで `visible`、0 になってから `hidden` |
| 閉: 区切り線 / 角丸 / 高さ | すべて 220ms で同時に着地 (継ぎ目なし) |
| 最下部で閉じる | 結果帯の高さは 165px で不動 (フレーム間の変動 0px)、`--dock` も不変 |
| キーボード | 畳んだ状態から Tab x4、パネル内には一度も到達しない |
| `prefers-reduced-motion: reduce` | 開閉とも 1〜2 フレームで完了、走るトランジション 0 本 |
| 375x812 (タッチエミュレーション) | 開 260px 即確定 / 閉 200ms、横スクロール無し |
| ライト / ダーク | 閉時に余計なハイラインが出ないこと、開時に区切り線が出ることを目視確認 |

`pnpm lint` / `pnpm build` / `pnpm test` (12 pass) いずれも通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)